### PR TITLE
Ignore CCPM cursor install paths by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Teams using this system report:
    curl -o ccpm.bat https://automaze.io/ccpm/install && ccpm.bat --target cursor
    ```
 
-   > ✅ **Note**: The default install target copies `ccpm/` to `.claude/`. The Cursor target copies `cursor-ccpm/commands` and `cursor-ccpm/ccpm` into `.cursor/`.
+   > ✅ **Note**: The default install target copies `ccpm/` to `.claude/`. The Cursor target copies `cursor-ccpm/commands` and `cursor-ccpm/ccpm` into `.cursor/`, then adds `.cursor/commands/` and `.cursor/ccpm/` to `.gitignore`.
 
    See full/other installation options in the [installation guide ›](https://github.com/automazeio/ccpm/tree/main/install)
 

--- a/install/README.md
+++ b/install/README.md
@@ -44,9 +44,16 @@ Cursor target:
 curl -o ccpm.bat https://automaze.io/ccpm/install && ccpm.bat --target cursor
 ```
 
+Cursor installs automatically add these CCPM-managed paths to `.gitignore`:
+
+```gitignore
+.cursor/ccpm/
+.cursor/commands/
+```
+
 ## One-liner alternatives
 
-> ⚠️ **Note**: These one-liners don't automatically copy a payload into `.claude/` or `.cursor/`. After cloning, copy either `ccpm/` into `.claude/` or `cursor-ccpm/{commands,ccpm}` into `.cursor/{commands,ccpm}`.
+> ⚠️ **Note**: These one-liners don't automatically copy a payload into `.claude/` or `.cursor/`, and they also won't add the Cursor CCPM paths to `.gitignore`. After cloning, copy either `ccpm/` into `.claude/` or `cursor-ccpm/{commands,ccpm}` into `.cursor/{commands,ccpm}`.
 
 ### Unix/Linux/macOS (direct commands)
 ```bash

--- a/install/ccpm.bat
+++ b/install/ccpm.bat
@@ -80,8 +80,12 @@ if /I "%INSTALL_TARGET%"=="claude" (
     if exist cursor-ccpm\ccpm (
         echo Copying cursor ccpm payload to .cursor\ccpm...
         xcopy /E /I /Y cursor-ccpm\ccpm .cursor\ccpm >nul
-        echo ✅ CCPM files installed to .cursor/
     )
+
+    if not exist .gitignore type nul > .gitignore
+    findstr /X /C:".cursor/ccpm/" .gitignore >nul || echo .cursor/ccpm/>>.gitignore
+    findstr /X /C:".cursor/commands/" .gitignore >nul || echo .cursor/commands/>>.gitignore
+    echo ✅ CCPM files installed to .cursor/
 )
 
 echo Cleaning up...
@@ -89,6 +93,5 @@ rmdir /s /q .git 2>nul
 rmdir /s /q install 2>nul
 rmdir /s /q ccpm 2>nul
 rmdir /s /q cursor-ccpm 2>nul
-del /q .gitignore 2>nul
 echo ✅ Installation complete. Repository is now untracked.
 endlocal

--- a/install/ccpm.sh
+++ b/install/ccpm.sh
@@ -41,5 +41,5 @@ echo "Installing target '$INSTALL_TARGET'..."
 bash ./project-install.sh "$TARGET_DIR" --target "$INSTALL_TARGET"
 
 echo "Cleaning up..."
-rm -rf .git .gitignore install ccpm cursor-ccpm
+rm -rf .git install ccpm cursor-ccpm
 echo "✅ Installation complete. Repository is now untracked."

--- a/project-install.sh
+++ b/project-install.sh
@@ -51,6 +51,16 @@ copy_dir_contents() {
     cp -R "$source_dir"/. "$dest_dir"/
 }
 
+ensure_gitignore_entry() {
+    local gitignore_file="$1"
+    local entry="$2"
+
+    touch "$gitignore_file"
+    if ! grep -Fxq "$entry" "$gitignore_file"; then
+        printf "%s\n" "$entry" >> "$gitignore_file"
+    fi
+}
+
 # Check for target directory argument
 if [ -z "$1" ]; then
     echo -e "${RED}Error: Target directory is required${NC}"
@@ -163,6 +173,9 @@ else
         exit 1
     fi
 
+    ensure_gitignore_entry "$TARGET_DIR/.gitignore" ".cursor/ccpm/"
+    ensure_gitignore_entry "$TARGET_DIR/.gitignore" ".cursor/commands/"
+
     FILE_COUNT=$(find "$TARGET_DIR/.cursor" -type f | wc -l | tr -d ' ')
 
     echo ""
@@ -171,10 +184,14 @@ else
     echo "Installed $FILE_COUNT files to: $TARGET_DIR/.cursor/"
     echo ""
     echo -e "${YELLOW}Next steps:${NC}"
-    echo "1. Initialize the PM system:"
+    echo "1. Added CCPM-managed Cursor paths to .gitignore:"
+    echo "   .cursor/ccpm/"
+    echo "   .cursor/commands/"
+    echo ""
+    echo "2. Initialize the PM system:"
     echo "   /pm:init"
     echo ""
-    echo "2. Prime the project context:"
+    echo "3. Prime the project context:"
     echo "   /context:create"
 fi
 


### PR DESCRIPTION
## Summary
- auto-add `.cursor/ccpm/` and `.cursor/commands/` to `.gitignore` for Cursor installs
- preserve `.gitignore` during installer cleanup so the new ignore entries persist
- update docs to reflect the automatic Cursor ignore behavior

## Testing
- `bash -n project-install.sh`
- `bash -n install/ccpm.sh`
- temp-repo smoke tests for Cursor `.gitignore` creation, duplicate prevention, existing-content preservation, and unchanged Claude behavior