### PR TITLE
Add nested planning storage to skill-based CCPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ For older repos with `.claude/prds` and `.claude/epics`, run:
 bash skill/ccpm/references/scripts/migrate-layout.sh
 ```
 
+Review the dry-run output, then apply the migration:
+
+```bash
+bash skill/ccpm/references/scripts/migrate-layout.sh --apply
+```
+
 The pre-migration layout is preserved locally via:
 - tag: `legacy-pre-skills-layout`
 - branch: `codex/legacy-pre-skills-layout`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CCPM gives your agent a repo-backed delivery workflow:
 - preserve project context in `.claude/context/`
 - detect and run tests through `.claude/testing-config.md`
 
-The installed skill location is harness-specific, but CCPM project state always lives in `.claude/` at the project root.
+The installed skill location is harness-specific. Planning artifacts live under `docs/prds/` by default, while CCPM config/context/testing state lives under `.claude/` at the project root.
 
 ## Install
 
@@ -103,9 +103,18 @@ skill/ccpm/
 Project data layout:
 
 ```text
+docs/prds/
+└── <prd-name>/
+    ├── prd.md
+    └── epics/
+        └── <epic-name>/
+            ├── epic.md
+            ├── issues/
+            ├── updates/
+            └── github-mapping.md
+
 .claude/
-├── prds/
-├── epics/
+├── .ccpmrc
 ├── context/
 └── testing-config.md
 ```
@@ -117,6 +126,12 @@ This fork retires the old `/pm:*` payload model in favor of the single installed
 See:
 - [MIGRATION.md](MIGRATION.md)
 - [UPSTREAM_SYNC.md](UPSTREAM_SYNC.md)
+
+For older repos with `.claude/prds` and `.claude/epics`, run:
+
+```bash
+bash skill/ccpm/references/scripts/migrate-layout.sh
+```
 
 The pre-migration layout is preserved locally via:
 - tag: `legacy-pre-skills-layout`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Review the dry-run output, then apply the migration:
 bash skill/ccpm/references/scripts/migrate-layout.sh --apply
 ```
 
-Duplicate hidden epics that collide with an active nested epic are quarantined under the legacy hidden root's `.archived/duplicate-name-conflicts/` path so they no longer interfere with active epic resolution.
+Duplicate hidden epics that collide with an active nested epic are quarantined under the legacy hidden root's `.archived/duplicate-name-conflicts/` path. Hidden epics that map to the same nested target but contain conflicting content are quarantined under `.archived/merge-conflicts/` so they do not interfere with active epic resolution.
 
 The pre-migration layout is preserved locally via:
 - tag: `legacy-pre-skills-layout`

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Review the dry-run output, then apply the migration:
 bash skill/ccpm/references/scripts/migrate-layout.sh --apply
 ```
 
+Duplicate hidden epics that collide with an active nested epic are quarantined under the legacy hidden root's `.archived/duplicate-name-conflicts/` path so they no longer interfere with active epic resolution.
+
 The pre-migration layout is preserved locally via:
 - tag: `legacy-pre-skills-layout`
 - branch: `codex/legacy-pre-skills-layout`

--- a/skill/ccpm/SKILL.md
+++ b/skill/ccpm/SKILL.md
@@ -9,28 +9,34 @@ A spec-driven development workflow: PRD → Epic → GitHub Issues → Parallel 
 
 ## Core Philosophy
 
-Requirements live in files, not heads. Every feature starts as a PRD, becomes a technical epic, decomposes into GitHub issues, and gets executed by parallel agents with full traceability.
+Requirements live in repo-visible files, not hidden tooling folders. PRDs, epics, issues, analyses, and updates should live under the configured planning root, while `.claude/` is reserved for CCPM config, context, and testing metadata.
 
 ## File Conventions
 
-Before doing anything, read `references/conventions.md` for path standards, frontmatter schemas, and GitHub operation rules. These apply to all phases.
+Before doing anything, read `references/conventions.md` for storage paths, frontmatter schemas, and GitHub operation rules. These apply to all phases.
 
 ## Project Data Convention
 
 This skill may be installed into different harness-specific skill directories such as `.claude/skills/ccpm`, `.cursor/skills/ccpm`, or `skills/ccpm`.
 
-Regardless of where the skill itself is installed, CCPM stores its project state in `.claude/` at the project root:
-- `.claude/prds/`
-- `.claude/epics/`
-- `.claude/context/`
-- `.claude/testing-config.md`
+Regardless of where the skill itself is installed:
+- planning artifacts live under `PRD_DIR`, defaulting to `docs/prds/`
+- CCPM config remains in `.claude/.ccpmrc`
+- context remains in `.claude/context/`
+- testing config remains in `.claude/testing-config.md`
+
+Use the resolver scripts under `references/scripts/` instead of hardcoding planning paths:
+- `resolve-prd-dir.sh`
+- `resolve-prd-path.sh`
+- `resolve-epic-dir.sh`
+- `resolve-issue-file.sh`
 
 ## The Five Phases
 
 ### 1. Plan — Capture requirements
 **When**: User wants to define a new feature, product requirement, or scope of work.
 **Read**: `references/plan.md`
-**Covers**: Writing PRDs through guided brainstorming, converting PRDs to technical epics.
+**Covers**: Writing PRDs through guided brainstorming, converting PRDs to one or more technical epics.
 
 ### 2. Structure — Break it down
 **When**: An epic exists and needs to be decomposed into concrete tasks.
@@ -40,12 +46,12 @@ Regardless of where the skill itself is installed, CCPM stores its project state
 ### 3. Sync — Push to GitHub
 **When**: Local epic/tasks need to become GitHub issues, progress needs to be posted as comments, or a bug is found and needs a linked issue created.
 **Read**: `references/sync.md`
-**Covers**: Epic sync (epic + tasks → GitHub issues), issue sync (progress comments), closing issues/epics, bug reporting against completed issues.
+**Covers**: Epic sync, issue sync, closing issues/epics, bug reporting against completed issues.
 
 ### 4. Execute — Start building
 **When**: User wants to start working on one or more GitHub issues with parallel agents.
 **Read**: `references/execute.md`
-**Covers**: Issue analysis (parallel work stream identification), launching parallel agents, coordinating worktrees.
+**Covers**: Issue analysis, launching parallel agents, coordinating worktrees.
 
 ### 5. Track — Know where things stand
 **When**: User asks for status, standup report, what's blocked, what's next, or needs to validate state.
@@ -84,6 +90,7 @@ For deterministic operations — anything that reads and reports without needing
 | What's next | `bash references/scripts/next.sh` |
 | What's blocked | `bash references/scripts/blocked.sh` |
 | Validate project state | `bash references/scripts/validate.sh` |
+| Migrate from legacy `.claude` layout | `bash references/scripts/migrate-layout.sh [--apply]` |
 | Run a specific test with log capture | `bash references/scripts/test-and-log.sh <test_target> [log_name]` |
 
 Use the LLM for work that requires reasoning: writing PRDs, analyzing parallelism, launching agents, synthesizing updates.
@@ -95,6 +102,7 @@ Use the LLM for work that requires reasoning: writing PRDs, analyzing parallelis
 ```
 Plan a feature:     "I want to build X" or "create a PRD for X"
 Parse to epic:      "turn the X PRD into an epic"
+Parse to named epic:"turn the X PRD into the Y epic"
 Decompose:          "break down the X epic into tasks"
 Sync to GitHub:     "push the X epic to GitHub"
 Start an issue:     "start working on issue 42"
@@ -107,4 +115,5 @@ Refresh context:    "update project context"
 Prime context:      "prime context for this repo"
 Prime testing:      "figure out this repo's test setup"
 Run tests:          "run the auth tests" / "run pytest for api/tests/test_users.py"
+Migrate layout:     "migrate the planning layout"
 ```

--- a/skill/ccpm/references/conventions.md
+++ b/skill/ccpm/references/conventions.md
@@ -4,72 +4,91 @@ Read this before doing any file operations across all phases.
 
 ---
 
-## Directory Structure
+## Planning Storage
 
+Use resolver scripts instead of hardcoded planning paths:
+
+```bash
+PRD_DIR=$(bash references/scripts/resolve-prd-dir.sh)
+PRD_PATH=$(bash references/scripts/resolve-prd-path.sh <prd-name>)
+EPIC_DIR=$(bash references/scripts/resolve-epic-dir.sh <epic-name>)
+ISSUE_FILE=$(bash references/scripts/resolve-issue-file.sh <issue-number>)
 ```
-.claude/
-├── prds/
-│   └── <feature-name>.md          # Product requirement documents
-├── epics/
-│   ├── <feature-name>/
-│   │   ├── epic.md                # Technical epic
-│   │   ├── <N>.md                 # Task files (named by GitHub issue number after sync)
-│   │   ├── <N>-analysis.md        # Parallel work stream analysis
-│   │   ├── github-mapping.md      # Issue number → URL mapping
-│   │   ├── execution-status.md    # Active agents tracker
-│   │   └── updates/
-│   │       └── <issue_N>/
-│   │           ├── stream-A.md    # Per-agent progress
-│   │           ├── progress.md    # Overall issue progress
-│   │           └── execution.md  # Execution state
-│   └── archived/
-│       └── <feature-name>/        # Completed epics
-├── context/                       # Project context docs
-└── testing-config.md              # Test runner configuration for this repo
+
+For new repos, planning artifacts live under `docs/prds/` by default. `.claude/` remains for config, context, and testing.
+
+### Canonical Layout
+
+```text
+<PRD_DIR>/
+└── <prd-name>/
+    ├── prd.md
+    └── epics/
+        ├── <epic-name>/
+        │   ├── epic.md
+        │   ├── issues/
+        │   │   └── <N>.md
+        │   ├── <N>-analysis.md
+        │   ├── github-mapping.md
+        │   ├── execution-status.md
+        │   └── updates/
+        │       └── <issue_N>/
+        │           ├── stream-A.md
+        │           ├── progress.md
+        │           └── execution.md
+        └── .archived/
+            └── <epic-name>/
 ```
+
+### Compatibility Rules
+
+- Prefer `<PRD_DIR>/<name>/prd.md` over flat `<PRD_DIR>/<name>.md`.
+- Prefer `<PRD_DIR>/<prd>/epics/<epic>/` over `.claude/epics/<epic>/`.
+- Prefer `<epic>/issues/<N>.md` over `<epic>/<N>.md`.
+- Preserve backward compatibility for reading until the repo is explicitly migrated.
 
 ---
 
 ## Frontmatter Schemas
 
-### PRD (.claude/prds/<name>.md)
-```yaml
----
-name: <feature-name>        # kebab-case, matches filename
-description: <one-liner>    # used in lists and summaries
-status: backlog | active | completed
-created: <ISO 8601>         # date -u +"%Y-%m-%dT%H:%M:%SZ"
----
-```
-
-### Epic (.claude/epics/<name>/epic.md)
+### PRD (`<PRD_DIR>/<name>/prd.md`)
 ```yaml
 ---
 name: <feature-name>
-status: backlog | in-progress | completed
+description: <one-liner>
+status: backlog | active | completed
 created: <ISO 8601>
-updated: <ISO 8601>
-progress: 0%                # recalculated when tasks close
-prd: .claude/prds/<name>.md
-github: https://github.com/<owner>/<repo>/issues/<N>  # set on sync
 ---
 ```
 
-### Task (.claude/epics/<name>/<N>.md)
+### Epic (`<PRD_DIR>/<prd>/epics/<epic>/epic.md`)
+```yaml
+---
+name: <epic-name>
+status: backlog | in-progress | completed
+created: <ISO 8601>
+updated: <ISO 8601>
+progress: 0%
+prd: <PRD_DIR>/<prd>/prd.md
+github: https://github.com/<owner>/<repo>/issues/<N>
+---
+```
+
+### Task (`<epic>/issues/<N>.md`)
 ```yaml
 ---
 name: <Task Title>
 status: open | in-progress | closed
 created: <ISO 8601>
 updated: <ISO 8601>
-github: https://github.com/<owner>/<repo>/issues/<N>  # set on sync
-depends_on: []              # issue numbers this must wait for
-parallel: true              # can run concurrently with non-conflicting tasks
-conflicts_with: []          # issue numbers that touch the same files
+github: https://github.com/<owner>/<repo>/issues/<N>
+depends_on: []
+parallel: true
+conflicts_with: []
 ---
 ```
 
-### Progress (.claude/epics/<name>/updates/<N>/progress.md)
+### Progress (`<epic>/updates/<N>/progress.md`)
 ```yaml
 ---
 issue: <N>
@@ -79,7 +98,7 @@ completion: 0%
 ---
 ```
 
-### Testing Config (.claude/testing-config.md)
+### Testing Config (`.claude/testing-config.md`)
 ```yaml
 ---
 framework: <name>
@@ -90,37 +109,21 @@ last_updated: <ISO 8601>
 ---
 ```
 
-Contains the detected test setup for the current project. Additional fields such as `options` and `environment` may be added below the frontmatter as structured markdown.
-
 ---
 
 ## Datetime Rule
 
-Always get real current datetime from the system — never use placeholder text:
+Always get real current datetime from the system:
+
 ```bash
 date -u +"%Y-%m-%dT%H:%M:%SZ"
 ```
 
 ---
 
-## Frontmatter Update Pattern
-
-When updating a single frontmatter field in an existing file:
-```bash
-sed -i.bak "/^<field>:/c\\<field>: <value>" <file>
-rm <file>.bak
-```
-
-When stripping frontmatter to get body content for GitHub:
-```bash
-sed '1,/^---$/d; 1,/^---$/d' <file> > /tmp/body.md
-```
-
----
-
 ## GitHub Operations
 
-### Repository Safety Check (run before any write operation)
+### Repository Safety Check
 ```bash
 remote_url=$(git remote get-url origin 2>/dev/null || echo "")
 if [[ "$remote_url" == *"automazeio/ccpm"* ]] || [[ "$remote_url" == *"visualjc/ccpm"* ]]; then
@@ -132,15 +135,10 @@ REPO=$(echo "$remote_url" | sed 's|.*github.com[:/]||' | sed 's|\.git$||')
 ```
 
 ### Authentication
-Don't pre-check authentication. Run the `gh` command and handle failure:
+Run the `gh` command directly and handle failure:
+
 ```bash
 gh <command> || echo "❌ GitHub CLI failed. Run: gh auth login"
-```
-
-### Getting Issue Numbers
-```bash
-# From a task file's github field:
-grep 'github:' <file> | grep -oE '[0-9]+$'
 ```
 
 ---
@@ -148,31 +146,27 @@ grep 'github:' <file> | grep -oE '[0-9]+$'
 ## Git / Worktree Conventions
 
 - One branch per epic: `epic/<name>`
-- Worktrees live at `../epic-<name>/` (sibling to project root)
-- Always start branches from an up-to-date main:
-  ```bash
-  git checkout main && git pull origin main
-  git worktree add ../epic-<name> -b epic/<name>
-  ```
+- Worktrees live at `../epic-<name>/`
 - Commit format inside epics: `Issue #<N>: <description>`
-- Never use `--force` in any git operation
+- Never use `--force` in git operations
 
 ---
 
 ## Naming Conventions
 
-- Feature names: kebab-case, lowercase, letters/numbers/hyphens, starts with a letter
-- Task files before sync: `001.md`, `002.md`, ... (sequential)
-- Task files after sync: renamed to GitHub issue number (e.g., `1234.md`)
-- Labels applied on sync: `epic`, `epic:<name>`, `feature` (for epics); `task`, `epic:<name>` (for tasks)
+- PRD names: kebab-case and unique within the project
+- Epic names: kebab-case and unique across the project
+- Task files before sync: `001.md`, `002.md`, ...
+- Task files after sync: renamed to GitHub issue numbers
+- Archived epics move to `<PRD_DIR>/<prd>/epics/.archived/<epic>/`
 
 ---
 
 ## Epic Progress Calculation
 
 ```bash
-total=$(ls .claude/epics/<name>/[0-9]*.md 2>/dev/null | wc -l)
-closed=$(grep -l '^status: closed' .claude/epics/<name>/[0-9]*.md 2>/dev/null | wc -l)
+total=$(find <epic>/issues -mindepth 1 -maxdepth 1 -name '[0-9]*.md' | wc -l)
+closed=$(grep -l '^status: closed' <epic>/issues/[0-9]*.md 2>/dev/null | wc -l)
 progress=$((closed * 100 / total))
 ```
 

--- a/skill/ccpm/references/execute.md
+++ b/skill/ccpm/references/execute.md
@@ -9,7 +9,10 @@ This phase covers analyzing GitHub issues for parallel work streams and launchin
 **Trigger**: User wants to understand how to parallelize work on an issue before starting.
 
 ### Preflight
-- Find the local task file: check `.claude/epics/*/<N>.md` first, then search for `github:.*issues/<N>` in frontmatter.
+- Find the local task file with `bash references/scripts/resolve-issue-file.sh <N>`.
+- Derive the epic directory from that task file:
+  - nested: parent of `issues/`
+  - legacy: parent of the task file
 - If not found: "❌ No local task for issue #<N>. Run a sync first."
 
 ### Process
@@ -17,18 +20,11 @@ This phase covers analyzing GitHub issues for parallel work streams and launchin
 Get issue details: `gh issue view <N> --json title,body,labels`
 
 Read the local task file fully. Identify independent work streams by asking:
-- Which files will be created/modified?
+- Which files will be created or modified?
 - Which changes can happen simultaneously without conflict?
 - What are the dependencies between changes?
 
-**Common stream patterns:**
-- Database Layer: schema, migrations, models
-- Service Layer: business logic, data access
-- API Layer: endpoints, validation, middleware
-- UI Layer: components, pages, styles
-- Test Layer: unit tests, integration tests
-
-Create `.claude/epics/<epic_name>/<N>-analysis.md`:
+Create `<epic-dir>/<N>-analysis.md`:
 
 ```markdown
 ---
@@ -40,39 +36,8 @@ parallelization_factor: <1.0-5.0>
 ---
 
 # Parallel Work Analysis: Issue #<N>
-
-## Overview
-
-## Parallel Streams
-
-### Stream A: <Name>
-**Scope**: 
-**Files**: 
-**Can Start**: immediately
-**Estimated Hours**: 
-**Dependencies**: none
-
-### Stream B: <Name>
-**Scope**: 
-**Files**: 
-**Can Start**: after Stream A
-**Dependencies**: Stream A
-
-## Coordination Points
-### Shared Files
-### Sequential Requirements
-
-## Conflict Risk Assessment
-
-## Parallelization Strategy
-
-## Expected Timeline
-- With parallel execution: <max_stream_hours>h wall time
-- Without: <sum_all_hours>h
-- Efficiency gain: <pct>%
+...
 ```
-
-**Output**: "✅ Analysis complete for issue #<N> — N parallel streams identified. Ready to start? Say: start issue <N>"
 
 ---
 
@@ -81,91 +46,27 @@ parallelization_factor: <1.0-5.0>
 **Trigger**: User wants to begin work on a specific GitHub issue.
 
 ### Preflight
-1. Verify issue exists and is open: `gh issue view <N> --json state,title,labels,body`
-2. Find local task file (as above).
-3. Check for analysis file: `.claude/epics/*/<N>-analysis.md` — if missing, run analysis first (or do both in sequence: analyze then start).
-4. Verify epic worktree exists: `git worktree list | grep "epic-<name>"` — if not: "❌ No worktree. Sync the epic first."
+1. Verify the issue exists and is open.
+2. Resolve the local task file.
+3. Check for `<epic-dir>/<N>-analysis.md`; create it first if needed.
+4. Verify the epic worktree exists.
 
 ### Process
 
-**Step 1 — Read the analysis**, identify which streams can start immediately vs. which have dependencies.
+Use `<epic-dir>/updates/<N>/` for execution tracking:
 
-**Step 2 — Create progress tracking:**
 ```bash
-mkdir -p .claude/epics/<epic>/updates/<N>
-current_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+mkdir -p <epic-dir>/updates/<N>
 ```
 
-Create `.claude/epics/<epic>/updates/<N>/stream-<X>.md` for each stream:
-```markdown
----
-issue: <N>
-stream: <stream_name>
-started: <datetime>
-status: in_progress
----
-## Scope
-## Progress
-- Starting implementation
-```
+Create `<epic-dir>/updates/<N>/stream-<X>.md` files for each active stream and keep `<epic-dir>/updates/<N>/execution.md` as the execution summary.
 
-**Step 3 — Launch parallel agents** for each stream that can start immediately:
+When launching parallel agents, point them at:
+1. the resolved task file
+2. `<epic-dir>/<N>-analysis.md`
+3. `<epic-dir>/updates/<N>/stream-<X>.md`
 
-```yaml
-Task:
-  description: "Issue #<N> Stream <X>"
-  subagent_type: "general-purpose"
-  prompt: |
-    You are working on Issue #<N> in the epic worktree at: ../epic-<name>/
-    
-    Your stream: <stream_name>
-    Your scope — files to modify: <file_patterns>
-    Work to complete: <stream_description>
-    
-    Instructions:
-    1. Read full task from: .claude/epics/<epic>/<N>.md
-    2. Read analysis from: .claude/epics/<epic>/<N>-analysis.md
-    3. Work ONLY in your assigned files
-    4. Commit frequently: "Issue #<N>: <specific change>"
-    5. Update progress in: .claude/epics/<epic>/updates/<N>/stream-<X>.md
-    6. If you need to touch files outside your scope, note it in your progress file and wait
-    7. Never use --force on git operations
-    
-    Complete your stream's work and mark status: completed when done.
-```
-
-Streams with unmet dependencies are queued — launch them as their dependencies complete.
-
-**Step 4 — Assign on GitHub:**
-```bash
-gh issue edit <N> --add-assignee @me --add-label "in-progress"
-```
-
-**Step 5 — Create execution status file** at `.claude/epics/<epic>/updates/<N>/execution.md`:
-```markdown
-## Active Streams
-- Stream A: <name> — Started <time>
-- Stream B: <name> — Started <time>
-
-## Queued
-- Stream C: <name> — Waiting on Stream A
-
-## Completed
-(none yet)
-```
-
-**Output:**
-```
-✅ Started work on issue #<N>
-
-Launched N agents:
-  Stream A: <name> ✓ Started
-  Stream B: <name> ✓ Started
-  Stream C: <name> ⏸ Waiting (depends on A)
-
-Monitor: check progress in .claude/epics/<epic>/updates/<N>/
-Sync updates: "sync issue <N>"
-```
+Queued streams wait for dependencies to clear.
 
 ---
 
@@ -174,39 +75,13 @@ Sync updates: "sync issue <N>"
 **Trigger**: User wants to launch parallel agents across all ready issues in an epic at once.
 
 ### Preflight
-- Verify `.claude/epics/<name>/epic.md` exists and has a `github:` field (i.e., it's been synced).
-- Check for uncommitted changes: `git status --porcelain` — block if dirty.
-- Verify epic branch exists: `git branch -a | grep "epic/<name>"`
+- Resolve `<epic-dir>` and verify `epic.md` has a `github:` field.
+- Check for a clean worktree.
 
 ### Process
 
-**Step 1 — Read all task files** in `.claude/epics/<name>/`. Parse frontmatter for `status`, `depends_on`, `parallel`.
+Read all task files from:
+- canonical: `<epic-dir>/issues/*.md`
+- legacy fallback: `<epic-dir>/*.md`
 
-**Step 2 — Categorize tasks:**
-- Ready: status=open, no unmet depends_on
-- Blocked: has unmet depends_on
-- In Progress: already has an execution file
-- Complete: status=closed
-
-**Step 3 — Analyze any ready tasks** that don't have an analysis file yet (run issue analysis inline).
-
-**Step 4 — Launch agents** for all ready tasks following the same per-issue agent launch pattern above.
-
-**Step 5 — Create/update** `.claude/epics/<name>/execution-status.md` with all active agents and queued issues.
-
-**Step 6 — As agents complete**, check if blocked issues are now unblocked and launch those agents.
-
----
-
-## Agent Coordination Rules
-
-When multiple agents work in the same worktree simultaneously:
-
-- Each agent works only on files in its assigned stream scope.
-- Agents commit frequently with `Issue #<N>: <description>` format.
-- Before modifying a shared file, check `git status <file>` — if another agent has it modified, wait and pull first.
-- Agents sync via commits: `git pull --rebase origin epic/<name>` before starting new file work.
-- Conflicts are never auto-resolved — agents report them and pause.
-- No `--force` flags ever.
-
-Shared files that commonly need coordination (types, config, package.json) should be handled by one designated stream; others pull after that commit.
+Categorize tasks into ready, blocked, in-progress, and complete, then launch agents for all ready tasks and maintain `<epic-dir>/execution-status.md`.

--- a/skill/ccpm/references/plan.md
+++ b/skill/ccpm/references/plan.md
@@ -1,6 +1,6 @@
 # Plan — Capture Requirements
 
-This phase turns an idea into a structured PRD, then converts the PRD into a technical epic ready for decomposition.
+This phase turns an idea into a structured PRD, then converts the PRD into one or more technical epics ready for decomposition.
 
 ---
 
@@ -9,9 +9,10 @@ This phase turns an idea into a structured PRD, then converts the PRD into a tec
 **Trigger**: User wants to plan a new feature, product requirement, or area of work.
 
 ### Preflight
-- Check if `.claude/prds/<name>.md` already exists — if so, confirm overwrite before proceeding.
-- Ensure `.claude/prds/` directory exists; create it if not.
-- Feature name must be kebab-case (lowercase, letters/numbers/hyphens, starts with a letter). If not: "❌ Feature name must be kebab-case. Example: user-auth, payment-v2"
+- Resolve the planning root with `bash references/scripts/resolve-prd-dir.sh --ensure`.
+- Use `<PRD_DIR>/<name>/prd.md` as the canonical PRD path.
+- If `<PRD_DIR>/<name>/prd.md` or legacy `<PRD_DIR>/<name>.md` already exists, confirm overwrite before proceeding.
+- Feature name must be kebab-case.
 
 ### Process
 
@@ -22,7 +23,7 @@ Conduct a genuine brainstorming session before writing anything. Ask the user:
 - What's explicitly out of scope?
 - What are the constraints (tech, time, resources)?
 
-Then write `.claude/prds/<name>.md` with this frontmatter and structure:
+Then write `<PRD_DIR>/<name>/prd.md` with:
 
 ```markdown
 ---
@@ -45,13 +46,7 @@ created: <run: date -u +"%Y-%m-%dT%H:%M:%SZ">
 ## Dependencies
 ```
 
-**Quality gates before saving:**
-- No placeholder text in any section
-- User stories include acceptance criteria
-- Success criteria are measurable
-- Out of scope is explicitly listed
-
-**After creation**: Confirm "✅ PRD created: `.claude/prds/<name>.md`" and suggest: "Ready to create technical epic? Say: parse the <name> PRD"
+**After creation**: Confirm the resolved PRD path and suggest parsing it into an epic.
 
 ---
 
@@ -60,24 +55,29 @@ created: <run: date -u +"%Y-%m-%dT%H:%M:%SZ">
 **Trigger**: User wants to convert an existing PRD into a technical implementation plan.
 
 ### Preflight
-- Verify `.claude/prds/<name>.md` exists with valid frontmatter (name, description, status, created).
-- Check if `.claude/epics/<name>/epic.md` already exists — confirm overwrite if so.
+- Resolve the PRD with `bash references/scripts/resolve-prd-path.sh <prd-name>`.
+- Determine the epic name:
+  - default: same as the PRD name
+  - if the user clearly requests a named epic, use that epic name instead
+- Resolve the epic directory with `bash references/scripts/resolve-epic-dir.sh --ensure <prd-name> <epic-name>`.
+- If `epic.md` already exists there, confirm overwrite before proceeding.
 
 ### Process
 
-Read the PRD fully, then produce `.claude/epics/<name>/epic.md`:
+Read the PRD fully, then produce `<epic-dir>/epic.md`:
 
 ```markdown
 ---
-name: <feature-name>
+name: <epic-name>
 status: backlog
 created: <run: date -u +"%Y-%m-%dT%H:%M:%SZ">
+updated: <same as created>
 progress: 0%
-prd: .claude/prds/<name>.md
+prd: <resolved prd path>
 github: (will be set on sync)
 ---
 
-# Epic: <feature-name>
+# Epic: <epic-name>
 
 ## Overview
 ## Architecture Decisions
@@ -93,14 +93,14 @@ github: (will be set on sync)
 ```
 
 **Key constraints:**
-- Aim for ≤10 tasks total — prefer simplicity over completeness.
-- Look for ways to leverage existing functionality before creating new code.
-- Identify parallelization opportunities in the task breakdown preview.
+- Aim for ≤10 tasks total.
+- Prefer existing functionality over new surface area.
+- Identify parallelization opportunities.
 
-**After creation**: Confirm "✅ Epic created: `.claude/epics/<name>/epic.md`" and suggest: "Ready to decompose into tasks? Say: decompose the <name> epic"
+**After creation**: Confirm the resolved epic path and suggest decomposition.
 
 ---
 
 ## Editing a PRD or Epic
 
-Read the file first, make targeted edits preserving all frontmatter. Update the `updated` frontmatter field with current datetime.
+Read the resolved file first. Make targeted edits while preserving frontmatter and update `updated:` with the current datetime.

--- a/skill/ccpm/references/scripts/blocked.sh
+++ b/skill/ccpm/references/scripts/blocked.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
+
 echo "Getting tasks..."
 echo ""
 echo ""
@@ -9,13 +15,11 @@ echo ""
 
 found=0
 
-for epic_dir in .claude/epics/*/; do
-  [ -d "$epic_dir" ] || continue
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
   epic_name=$(basename "$epic_dir")
 
-  for task_file in "$epic_dir"/[0-9]*.md; do
-    [ -f "$task_file" ] || continue
-
+  while IFS= read -r task_file; do
     # Check if task is open
     status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
     if [ "$status" != "open" ] && [ -n "$status" ]; then
@@ -42,19 +46,23 @@ for epic_dir in .claude/epics/*/; do
       # Check status of dependencies
       open_deps=""
       for dep in $deps; do
-        dep_file="$epic_dir$dep.md"
+        dep_file="$(ccpm_task_file_for_epic_issue "$epic_dir" "$dep" 2>/dev/null || true)"
         if [ -f "$dep_file" ]; then
           dep_status=$(grep "^status:" "$dep_file" | head -1 | sed 's/^status: *//')
-          [ "$dep_status" = "open" ] && open_deps="$open_deps #$dep"
+          if [ "$dep_status" != "closed" ] && [ "$dep_status" != "completed" ]; then
+            open_deps="$open_deps #$dep"
+          fi
         fi
       done
 
-      [ -n "$open_deps" ] && echo "   Waiting for:$open_deps"
-      echo ""
-      ((found++))
+      if [ -n "$open_deps" ]; then
+        echo "   Waiting for:$open_deps"
+        echo ""
+        ((found++))
+      fi
     fi
-  done
-done
+  done < <(ccpm_list_task_files_for_epic "$epic_dir")
+done < <(ccpm_list_epic_dirs)
 
 if [ $found -eq 0 ]; then
   echo "No blocked tasks found!"

--- a/skill/ccpm/references/scripts/epic-list.sh
+++ b/skill/ccpm/references/scripts/epic-list.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
+
 echo "Getting epics..."
 echo ""
 echo ""
 
-[ ! -d ".claude/epics" ] && echo "📁 No epics directory found. Ask CCPM: parse the <feature-name> PRD" && exit 0
-[ -z "$(ls -d .claude/epics/*/ 2>/dev/null)" ] && echo "📁 No epics found. Ask CCPM: parse the <feature-name> PRD" && exit 0
+if [ -z "$(ccpm_list_epic_dirs)" ]; then
+  echo "📁 No epics found. Ask CCPM: parse the <feature-name> PRD"
+  exit 0
+fi
 
 echo "📚 Project Epics"
 echo "================"
@@ -16,8 +24,8 @@ in_progress_epics=""
 completed_epics=""
 
 # Process all epics
-for dir in .claude/epics/*/; do
-  [ -d "$dir" ] || continue
+while IFS= read -r dir; do
+  [ -n "$dir" ] || continue
   [ -f "$dir/epic.md" ] || continue
 
   # Extract metadata
@@ -31,14 +39,14 @@ for dir in .claude/epics/*/; do
   [ -z "$p" ] && p="0%"
 
   # Count tasks
-  t=$(ls "$dir"/[0-9]*.md 2>/dev/null | wc -l)
+  t=$(ccpm_list_task_files_for_epic "$dir" | wc -l | tr -d '[:space:]')
 
   # Format output with GitHub issue number if available
   if [ -n "$g" ]; then
     i=$(echo "$g" | grep -o '/[0-9]*$' | tr -d '/')
-    entry="   📋 ${dir}epic.md (#$i) - $p complete ($t tasks)"
+    entry="   📋 ${dir}/epic.md (#$i) - $p complete ($t tasks)"
   else
-    entry="   📋 ${dir}epic.md - $p complete ($t tasks)"
+    entry="   📋 ${dir}/epic.md - $p complete ($t tasks)"
   fi
 
   # Categorize by status (handle various status values)
@@ -57,7 +65,7 @@ for dir in .claude/epics/*/; do
       planning_epics="${planning_epics}${entry}\n"
       ;;
   esac
-done
+done < <(ccpm_list_epic_dirs)
 
 # Display categorized epics
 echo "📝 Planning:"
@@ -86,8 +94,8 @@ fi
 # Summary
 echo ""
 echo "📊 Summary"
-total=$(ls -d .claude/epics/*/ 2>/dev/null | wc -l)
-tasks=$(find .claude/epics -name "[0-9]*.md" 2>/dev/null | wc -l)
+total=$(ccpm_list_epic_dirs | wc -l | tr -d '[:space:]')
+tasks=$(ccpm_list_task_files | wc -l | tr -d '[:space:]')
 echo "   Total epics: $total"
 echo "   Total tasks: $tasks"
 

--- a/skill/ccpm/references/scripts/epic-show.sh
+++ b/skill/ccpm/references/scripts/epic-show.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 epic_name="$1"
 
@@ -12,15 +17,15 @@ echo "Getting epic..."
 echo ""
 echo ""
 
-epic_dir=".claude/epics/$epic_name"
+epic_dir="$(ccpm_resolve_epic_dir "$epic_name" 2>/dev/null || true)"
 epic_file="$epic_dir/epic.md"
 
 if [ ! -f "$epic_file" ]; then
   echo "❌ Epic not found: $epic_name"
   echo ""
   echo "Available epics:"
-  for dir in .claude/epics/*/; do
-    [ -d "$dir" ] && echo "  • $(basename "$dir")"
+  ccpm_list_epic_dirs | while IFS= read -r dir; do
+    [ -n "$dir" ] && echo "  • $(basename "$dir")"
   done
   exit 1
 fi
@@ -49,9 +54,7 @@ task_count=0
 open_count=0
 closed_count=0
 
-for task_file in "$epic_dir"/[0-9]*.md; do
-  [ -f "$task_file" ] || continue
-
+while IFS= read -r task_file; do
   task_num=$(basename "$task_file" .md)
   task_name=$(grep "^name:" "$task_file" | head -1 | sed 's/^name: *//')
   task_status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
@@ -67,7 +70,7 @@ for task_file in "$epic_dir"/[0-9]*.md; do
   fi
 
   ((task_count++))
-done
+done < <(ccpm_list_task_files_for_epic "$epic_dir")
 
 if [ $task_count -eq 0 ]; then
   echo "  No tasks created yet"

--- a/skill/ccpm/references/scripts/epic-status.sh
+++ b/skill/ccpm/references/scripts/epic-status.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 echo "Getting status..."
 echo ""
@@ -11,21 +16,21 @@ if [ -z "$epic_name" ]; then
   echo "Usage: bash <installed_skill_dir>/references/scripts/epic-status.sh <epic-name>"
   echo ""
   echo "Available epics:"
-  for dir in .claude/epics/*/; do
-    [ -d "$dir" ] && echo "  • $(basename "$dir")"
+  ccpm_list_epic_dirs | while IFS= read -r dir; do
+    [ -n "$dir" ] && echo "  • $(basename "$dir")"
   done
   exit 1
 else
   # Show status for specific epic
-  epic_dir=".claude/epics/$epic_name"
+  epic_dir="$(ccpm_resolve_epic_dir "$epic_name" 2>/dev/null || true)"
   epic_file="$epic_dir/epic.md"
 
   if [ ! -f "$epic_file" ]; then
     echo "❌ Epic not found: $epic_name"
     echo ""
     echo "Available epics:"
-    for dir in .claude/epics/*/; do
-      [ -d "$dir" ] && echo "  • $(basename "$dir")"
+    ccpm_list_epic_dirs | while IFS= read -r dir; do
+      [ -n "$dir" ] && echo "  • $(basename "$dir")"
     done
     exit 1
   fi
@@ -46,8 +51,7 @@ else
   blocked=0
 
   # Use find to safely iterate over task files
-  for task_file in "$epic_dir"/[0-9]*.md; do
-    [ -f "$task_file" ] || continue
+  while IFS= read -r task_file; do
     ((total++))
 
     task_status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
@@ -56,11 +60,25 @@ else
     if [ "$task_status" = "closed" ] || [ "$task_status" = "completed" ]; then
       ((closed++))
     elif [ -n "$deps" ] && [ "$deps" != "depends_on:" ]; then
-      ((blocked++))
+      blocked_task=false
+      for dep in $(echo "$deps" | sed 's/,/ /g'); do
+        dep_file="$(ccpm_task_file_for_epic_issue "$epic_dir" "$dep" 2>/dev/null || true)"
+        if [ -f "$dep_file" ]; then
+          dep_status=$(grep "^status:" "$dep_file" | head -1 | sed 's/^status: *//')
+          if [ "$dep_status" != "closed" ] && [ "$dep_status" != "completed" ]; then
+            blocked_task=true
+          fi
+        fi
+      done
+      if $blocked_task; then
+        ((blocked++))
+      else
+        ((open++))
+      fi
     else
       ((open++))
     fi
-  done
+  done < <(ccpm_list_task_files_for_epic "$epic_dir")
 
   # Display progress bar
   if [ $total -gt 0 ]; then

--- a/skill/ccpm/references/scripts/in-progress.sh
+++ b/skill/ccpm/references/scripts/in-progress.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
+
 echo "Getting status..."
 echo ""
 echo ""
@@ -10,19 +16,19 @@ echo ""
 # Check for active work in updates directories
 found=0
 
-if [ -d ".claude/epics" ]; then
-  for updates_dir in .claude/epics/*/updates/*/; do
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
+  while IFS= read -r updates_dir; do
     [ -d "$updates_dir" ] || continue
-
     issue_num=$(basename "$updates_dir")
-    epic_name=$(basename $(dirname $(dirname "$updates_dir")))
+    epic_name=$(basename "$epic_dir")
 
     if [ -f "$updates_dir/progress.md" ]; then
       completion=$(grep "^completion:" "$updates_dir/progress.md" | head -1 | sed 's/^completion: *//')
       [ -z "$completion" ] && completion="0%"
 
       # Get task name from the task file
-      task_file=".claude/epics/$epic_name/$issue_num.md"
+      task_file="$(ccpm_task_file_for_epic_issue "$epic_dir" "$issue_num" 2>/dev/null || true)"
       if [ -f "$task_file" ]; then
         task_name=$(grep "^name:" "$task_file" | head -1 | sed 's/^name: *//')
       else
@@ -42,13 +48,13 @@ if [ -d ".claude/epics" ]; then
       echo ""
       ((found++))
     fi
-  done
-fi
+  done < <(find "$epic_dir/updates" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+done < <(ccpm_list_epic_dirs)
 
 # Also check for in-progress epics
 echo "📚 Active Epics:"
-for epic_dir in .claude/epics/*/; do
-  [ -d "$epic_dir" ] || continue
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
   [ -f "$epic_dir/epic.md" ] || continue
 
   status=$(grep "^status:" "$epic_dir/epic.md" | head -1 | sed 's/^status: *//')
@@ -60,7 +66,7 @@ for epic_dir in .claude/epics/*/; do
 
     echo "   • $epic_name - $progress complete"
   fi
-done
+done < <(ccpm_list_epic_dirs)
 
 echo ""
 if [ $found -eq 0 ]; then
@@ -68,7 +74,7 @@ if [ $found -eq 0 ]; then
   echo ""
   echo "💡 Ask CCPM: what should I work on next?"
 else
-  echo "📊 Total active items: $found"
+echo "📊 Total active items: $found"
 fi
 
 exit 0

--- a/skill/ccpm/references/scripts/init.sh
+++ b/skill/ccpm/references/scripts/init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "Initializing..."
 echo ""
@@ -66,11 +67,18 @@ fi
 # Create directory structure
 echo ""
 echo "📁 Creating directory structure..."
-mkdir -p .claude/prds
-mkdir -p .claude/epics
+mkdir -p .claude
+mkdir -p docs/prds
 mkdir -p .claude/rules
 mkdir -p .claude/agents
 mkdir -p .claude/scripts/pm
+if [ ! -f ".claude/.ccpmrc" ]; then
+  cat > .claude/.ccpmrc <<'EOF'
+PRD_DIR=docs/prds
+EPIC_STORAGE=nested
+EOF
+  echo "  ✅ Created .claude/.ccpmrc"
+fi
 echo "  ✅ Directories created"
 
 # Copy scripts if in main repo
@@ -184,6 +192,7 @@ echo "  Auth: $(gh auth status 2>&1 | grep -o 'Logged in to [^ ]*' || echo 'Not 
 echo ""
 echo "🎯 Next Steps:"
 echo "  1. Ask CCPM: I want to build <feature-name>"
+echo "  2. Ask CCPM: migrate the planning layout (if this repo already has .claude PRDs/epics)"
 echo "  2. Ask CCPM: what can you do?"
 echo "  3. Ask CCPM: what's our status?"
 echo ""

--- a/skill/ccpm/references/scripts/layout-common.sh
+++ b/skill/ccpm/references/scripts/layout-common.sh
@@ -44,6 +44,17 @@ ccpm_epic_prd_name_from_dir() {
   fi
 }
 
+ccpm_is_numeric_task_filename() {
+  case "$1" in
+    ''|*-analysis.md)
+      return 1
+      ;;
+    *)
+      [[ "$1" =~ ^[0-9]+\.md$ ]]
+      ;;
+  esac
+}
+
 ccpm_epic_is_archived() {
   case "$1" in
     */epics/.archived/*|.claude/epics/archived/*|.cursor/ccpm/epics/archived/*)
@@ -134,8 +145,9 @@ ccpm_list_task_files_for_epic() {
   fi
 
   while IFS= read -r -d '' task_file; do
+    ccpm_is_numeric_task_filename "$(basename "$task_file")" || continue
     printf '%s\n' "$task_file"
-  done < <(find "$task_root" -mindepth 1 -maxdepth 1 -type f -name '[0-9]*.md' -print0 2>/dev/null | sort -z)
+  done < <(find "$task_root" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
 }
 
 ccpm_list_task_files() {

--- a/skill/ccpm/references/scripts/layout-common.sh
+++ b/skill/ccpm/references/scripts/layout-common.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ccpm_resolve_prd_dir() {
+  "$SCRIPT_DIR/resolve-prd-dir.sh" "$@"
+}
+
+ccpm_resolve_prd_path() {
+  "$SCRIPT_DIR/resolve-prd-path.sh" "$@"
+}
+
+ccpm_resolve_epic_dir() {
+  "$SCRIPT_DIR/resolve-epic-dir.sh" "$@"
+}
+
+ccpm_resolve_issue_file() {
+  "$SCRIPT_DIR/resolve-issue-file.sh" "$@"
+}
+
+ccpm_prd_name_from_path() {
+  local prd_path
+  prd_path="$1"
+  if [ "$(basename "$prd_path")" = "prd.md" ]; then
+    basename "$(dirname "$prd_path")"
+  else
+    basename "$prd_path" .md
+  fi
+}
+
+ccpm_epic_name_from_dir() {
+  basename "$1"
+}
+
+ccpm_epic_prd_name_from_dir() {
+  local epic_dir
+  epic_dir="$1"
+  if [ "$(basename "$(dirname "$epic_dir")")" = "epics" ]; then
+    basename "$(dirname "$(dirname "$epic_dir")")"
+  else
+    echo ""
+  fi
+}
+
+ccpm_epic_is_archived() {
+  case "$1" in
+    */epics/.archived/*|.claude/epics/archived/*|.cursor/ccpm/epics/archived/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ccpm_legacy_prd_roots() {
+  [ -d ".claude/prds" ] && printf '%s\n' ".claude/prds"
+  [ -d ".cursor/ccpm/prds" ] && printf '%s\n' ".cursor/ccpm/prds"
+}
+
+ccpm_legacy_epic_roots() {
+  [ -d ".claude/epics" ] && printf '%s\n' ".claude/epics"
+  [ -d ".cursor/ccpm/epics" ] && printf '%s\n' ".cursor/ccpm/epics"
+}
+
+ccpm_list_prd_files() {
+  local prd_dir nested_dir nested_file flat_file prd_name legacy_root
+  local seen=""
+
+  prd_dir="$(ccpm_resolve_prd_dir --allow-missing 2>/dev/null)" || prd_dir=""
+  if [ -n "$prd_dir" ] && [ -d "$prd_dir" ]; then
+    while IFS= read -r -d '' nested_dir; do
+      nested_file="$nested_dir/prd.md"
+      [ -f "$nested_file" ] || continue
+      prd_name="$(basename "$nested_dir")"
+      seen="${seen}|${prd_name}|"
+      printf '%s\n' "$nested_file"
+    done < <(find "$prd_dir" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
+
+    while IFS= read -r -d '' flat_file; do
+      prd_name="$(basename "$flat_file" .md)"
+      case "$seen" in
+        *"|$prd_name|"*) continue ;;
+      esac
+      seen="${seen}|${prd_name}|"
+      printf '%s\n' "$flat_file"
+    done < <(find "$prd_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+  fi
+
+  while IFS= read -r legacy_root; do
+    [ -n "$legacy_root" ] || continue
+    while IFS= read -r -d '' flat_file; do
+      prd_name="$(basename "$flat_file" .md)"
+      case "$seen" in
+        *"|$prd_name|"*) continue ;;
+      esac
+      seen="${seen}|${prd_name}|"
+      printf '%s\n' "$flat_file"
+    done < <(find "$legacy_root" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+  done < <(ccpm_legacy_prd_roots)
+}
+
+ccpm_list_epic_dirs() {
+  local prd_dir epic_dir legacy_dir legacy_root
+
+  prd_dir="$(ccpm_resolve_prd_dir --allow-missing 2>/dev/null)" || prd_dir=""
+  if [ -n "$prd_dir" ] && [ -d "$prd_dir" ]; then
+    while IFS= read -r -d '' epic_dir; do
+      [ -f "$epic_dir/epic.md" ] || continue
+      ccpm_epic_is_archived "$epic_dir" && continue
+      printf '%s\n' "$epic_dir"
+    done < <(find "$prd_dir" -path '*/epics/*' -type d -print0 2>/dev/null | sort -z)
+  fi
+
+  while IFS= read -r legacy_root; do
+    [ -n "$legacy_root" ] || continue
+    while IFS= read -r -d '' legacy_dir; do
+      [ -f "$legacy_dir/epic.md" ] || continue
+      ccpm_epic_is_archived "$legacy_dir" && continue
+      printf '%s\n' "$legacy_dir"
+    done < <(find "$legacy_root" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
+  done < <(ccpm_legacy_epic_roots)
+}
+
+ccpm_list_task_files_for_epic() {
+  local epic_dir task_root task_file
+  epic_dir="$1"
+  if [ -d "$epic_dir/issues" ]; then
+    task_root="$epic_dir/issues"
+  else
+    task_root="$epic_dir"
+  fi
+
+  while IFS= read -r -d '' task_file; do
+    printf '%s\n' "$task_file"
+  done < <(find "$task_root" -mindepth 1 -maxdepth 1 -type f -name '[0-9]*.md' -print0 2>/dev/null | sort -z)
+}
+
+ccpm_list_task_files() {
+  local epic_dir
+  while IFS= read -r epic_dir; do
+    [ -n "$epic_dir" ] || continue
+    ccpm_list_task_files_for_epic "$epic_dir"
+  done < <(ccpm_list_epic_dirs)
+}
+
+ccpm_epic_dir_from_task_file() {
+  local task_file
+  task_file="$1"
+  if [ "$(basename "$(dirname "$task_file")")" = "issues" ]; then
+    dirname "$(dirname "$task_file")"
+  else
+    dirname "$task_file"
+  fi
+}
+
+ccpm_task_file_for_epic_issue() {
+  local epic_dir issue_num
+  epic_dir="$1"
+  issue_num="$2"
+  if [ -f "$epic_dir/issues/$issue_num.md" ]; then
+    printf '%s\n' "$epic_dir/issues/$issue_num.md"
+    return 0
+  fi
+  if [ -f "$epic_dir/$issue_num.md" ]; then
+    printf '%s\n' "$epic_dir/$issue_num.md"
+    return 0
+  fi
+  return 1
+}
+
+ccpm_updates_dir_for_issue() {
+  local issue_file epic_dir issue_num
+  issue_num="$1"
+  issue_file="$(ccpm_resolve_issue_file "$issue_num" 2>/dev/null)" || return 1
+  epic_dir="$(ccpm_epic_dir_from_task_file "$issue_file")"
+  printf '%s\n' "$epic_dir/updates/$issue_num"
+}
+
+ccpm_recent_activity_roots() {
+  local prd_dir legacy_root
+  prd_dir="$(ccpm_resolve_prd_dir --allow-missing 2>/dev/null)" || prd_dir=""
+  [ -n "$prd_dir" ] && [ -d "$prd_dir" ] && printf '%s\n' "$prd_dir"
+  while IFS= read -r legacy_root; do
+    [ -n "$legacy_root" ] || continue
+    printf '%s\n' "$legacy_root"
+  done < <(ccpm_legacy_prd_roots)
+  while IFS= read -r legacy_root; do
+    [ -n "$legacy_root" ] || continue
+    printf '%s\n' "$legacy_root"
+  done < <(ccpm_legacy_epic_roots)
+}

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -245,6 +245,23 @@ top_level_numeric_task_files() {
   done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
 }
 
+planned_target_dir_conflict() {
+  local target_dir current conflict_path
+  target_dir="$1"
+  current="$target_dir"
+
+  while [ "$current" != "." ] && [ "$current" != "/" ]; do
+    conflict_path="$(required_dir_conflict "$current" || true)"
+    if [ -n "$conflict_path" ]; then
+      printf '%s\n' "$conflict_path"
+      return 0
+    fi
+    current="$(dirname "$current")"
+  done
+
+  return 1
+}
+
 same_target_merge_conflict_path() {
   local epic_dir target_epic_dir child update_dir update_file relative_path target_path conflict_path first_child
   epic_dir="$1"
@@ -308,6 +325,13 @@ classify_legacy_epic_migration() {
   conflict_path="$(epic_name_conflict_exists "$epic_name" "$epic_dir" || true)"
   if [ -n "$conflict_path" ] && [ "$conflict_path" != "$target_epic_dir" ]; then
     MIGRATION_CLASSIFICATION="quarantine-duplicate-name"
+    MIGRATION_DETAIL="$conflict_path"
+    return 0
+  fi
+
+  conflict_path="$(planned_target_dir_conflict "$target_epic_dir" || true)"
+  if [ -n "$conflict_path" ]; then
+    MIGRATION_CLASSIFICATION="quarantine-same-target-conflict"
     MIGRATION_DETAIL="$conflict_path"
     return 0
   fi

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -133,20 +133,21 @@ quarantine_legacy_epic_conflict() {
   printf ')\n'
 }
 
-dest_conflicts_with_src() {
-  local src dest
-  src="$1"
-  dest="$2"
-
-  [ -e "$dest" ] || return 1
-  [ -f "$dest" ] && cmp -s "$src" "$dest" && return 1
-  return 0
+required_dir_conflict() {
+  local dir
+  dir="$1"
+  if [ -e "$dir" ] && [ ! -d "$dir" ]; then
+    printf '%s\n' "$dir"
+    return 0
+  fi
+  return 1
 }
 
-path_shape_conflict_path() {
-  local dest root current relative remainder
-  dest="$1"
-  root="$2"
+destination_file_conflict() {
+  local src dest root current relative remainder ancestor_conflict
+  src="$1"
+  dest="$2"
+  root="$3"
 
   current="$(dirname "$dest")"
   relative="${current#"$root"}"
@@ -157,8 +158,9 @@ path_shape_conflict_path() {
     IFS='/' read -r -a _ccpm_segments <<< "$relative"
     for _ccpm_segment in "${_ccpm_segments[@]}"; do
       remainder="$remainder/$_ccpm_segment"
-      if [ -e "$remainder" ] && [ ! -d "$remainder" ]; then
-        printf '%s\n' "$remainder"
+      ancestor_conflict="$(required_dir_conflict "$remainder" || true)"
+      if [ -n "$ancestor_conflict" ]; then
+        printf '%s\n' "$ancestor_conflict"
         unset _ccpm_segments _ccpm_segment
         return 0
       fi
@@ -166,9 +168,11 @@ path_shape_conflict_path() {
     unset _ccpm_segments _ccpm_segment
   fi
 
-  if [ -e "$dest" ] && [ ! -f "$dest" ]; then
-    printf '%s\n' "$dest"
-    return 0
+  if [ -e "$dest" ]; then
+    if [ ! -f "$dest" ] || ! cmp -s "$src" "$dest"; then
+      printf '%s\n' "$dest"
+      return 0
+    fi
   fi
 
   return 1
@@ -231,57 +235,89 @@ unsupported_legacy_epic_entry() {
   return 1
 }
 
+top_level_numeric_task_files() {
+  local epic_dir
+  epic_dir="$1"
+
+  while IFS= read -r -d '' entry; do
+    ccpm_is_numeric_task_filename "$(basename "$entry")" || continue
+    printf '%s\n' "$entry"
+  done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+}
+
 same_target_merge_conflict_path() {
-  local epic_dir target_epic_dir child update_entry relative_path target_path unsupported_path shape_conflict
+  local epic_dir target_epic_dir child update_dir update_file relative_path target_path conflict_path first_child
   epic_dir="$1"
   target_epic_dir="$2"
-
-  unsupported_path="$(unsupported_legacy_epic_entry "$epic_dir" || true)"
-  if [ -n "$unsupported_path" ]; then
-    printf '%s\n' "$unsupported_path"
-    return 0
-  fi
-
-  if [ -f "$epic_dir/epic.md" ] && path_shape_conflict_path "$target_epic_dir/issues" "$target_epic_dir" >/dev/null; then
-    path_shape_conflict_path "$target_epic_dir/issues" "$target_epic_dir"
-    return 0
-  fi
 
   while IFS= read -r -d '' child; do
     target_path="$(mapped_destination_for_legacy_child "$child" "$target_epic_dir" || true)"
     [ -n "$target_path" ] || continue
 
-    shape_conflict="$(path_shape_conflict_path "$target_path" "$target_epic_dir" || true)"
-    if [ -n "$shape_conflict" ]; then
-      printf '%s\n' "$shape_conflict"
-      return 0
-    fi
-    if dest_conflicts_with_src "$child" "$target_path"; then
-      printf '%s\n' "$target_path"
+    conflict_path="$(destination_file_conflict "$child" "$target_path" "$target_epic_dir" || true)"
+    if [ -n "$conflict_path" ]; then
+      printf '%s\n' "$conflict_path"
       return 0
     fi
   done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
 
   if [ -d "$epic_dir/updates" ]; then
-    shape_conflict="$(path_shape_conflict_path "$target_epic_dir/updates" "$target_epic_dir" || true)"
-    if [ -n "$shape_conflict" ]; then
-      printf '%s\n' "$shape_conflict"
-      return 0
-    fi
+    while IFS= read -r -d '' update_dir; do
+      first_child="$(find "$update_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)"
+      [ -n "$first_child" ] || continue
+      relative_path="${update_dir#$epic_dir/}"
+      target_path="$target_epic_dir/$relative_path"
+      conflict_path="$(required_dir_conflict "$target_path" || true)"
+      if [ -n "$conflict_path" ]; then
+        printf '%s\n' "$conflict_path"
+        return 0
+      fi
+    done < <(find "$epic_dir/updates" -type d -print0 2>/dev/null | sort -z)
 
-    while IFS= read -r -d '' update_entry; do
-      relative_path="${update_entry#$epic_dir/updates/}"
-      target_path="$target_epic_dir/updates/$relative_path"
-      shape_conflict="$(path_shape_conflict_path "$target_path" "$target_epic_dir" || true)"
-      if [ -n "$shape_conflict" ]; then
-        printf '%s\n' "$shape_conflict"
+    while IFS= read -r -d '' update_file; do
+      relative_path="${update_file#$epic_dir/}"
+      target_path="$target_epic_dir/$relative_path"
+      conflict_path="$(destination_file_conflict "$update_file" "$target_path" "$target_epic_dir" || true)"
+      if [ -n "$conflict_path" ]; then
+        printf '%s\n' "$conflict_path"
         return 0
       fi
-      if dest_conflicts_with_src "$update_entry" "$target_path"; then
-        printf '%s\n' "$target_path"
-        return 0
-      fi
-    done < <(find "$epic_dir/updates" -mindepth 1 -print0 2>/dev/null | sort -z)
+    done < <(find "$epic_dir/updates" -type f -print0 2>/dev/null | sort -z)
+  fi
+}
+
+MIGRATION_CLASSIFICATION=""
+MIGRATION_DETAIL=""
+
+classify_legacy_epic_migration() {
+  local epic_dir target_epic_dir epic_name conflict_path unsupported_path
+  epic_dir="$1"
+  target_epic_dir="$2"
+  epic_name="$(basename "$epic_dir")"
+
+  MIGRATION_CLASSIFICATION="safe-merge"
+  MIGRATION_DETAIL=""
+
+  unsupported_path="$(unsupported_legacy_epic_entry "$epic_dir" || true)"
+  if [ -n "$unsupported_path" ]; then
+    MIGRATION_CLASSIFICATION="quarantine-unsupported-content"
+    MIGRATION_DETAIL="$unsupported_path"
+    return 0
+  fi
+
+  conflict_path="$(epic_name_conflict_exists "$epic_name" "$epic_dir" || true)"
+  if [ -n "$conflict_path" ] && [ "$conflict_path" != "$target_epic_dir" ]; then
+    MIGRATION_CLASSIFICATION="quarantine-duplicate-name"
+    MIGRATION_DETAIL="$conflict_path"
+    return 0
+  fi
+
+  if [ -d "$target_epic_dir" ]; then
+    conflict_path="$(same_target_merge_conflict_path "$epic_dir" "$target_epic_dir" || true)"
+    if [ -n "$conflict_path" ]; then
+      MIGRATION_CLASSIFICATION="quarantine-same-target-conflict"
+      MIGRATION_DETAIL="$conflict_path"
+    fi
   fi
 }
 
@@ -311,30 +347,20 @@ normalize_nested_epic_dirs() {
     [ -f "$epic_dir/epic.md" ] || continue
 
     issue_conflict=""
-    while IFS= read -r -d '' child; do
+    while IFS= read -r child; do
       name="$(basename "$child")"
-      ccpm_is_numeric_task_filename "$name" || continue
-      issue_conflict="$(path_shape_conflict_path "$epic_dir/issues/$name" "$epic_dir" || true)"
+      issue_conflict="$(destination_file_conflict "$child" "$epic_dir/issues/$name" "$epic_dir" || true)"
       if [ -n "$issue_conflict" ]; then
         printf 'ERROR nested normalization conflict: %s requires directory-compatible path for %s\n' "$epic_dir" "$issue_conflict" >&2
         return 1
       fi
-    done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+    done < <(top_level_numeric_task_files "$epic_dir")
 
-    while IFS= read -r -d '' child; do
+    while IFS= read -r child; do
       name="$(basename "$child")"
-      case "$name" in
-        [0-9]*-analysis.md)
-          # Old nested layouts already keep analysis files at epic root.
-          continue
-          ;;
-        *.md)
-          ccpm_is_numeric_task_filename "$name" || continue
-          ensure_dir "$epic_dir/issues"
-          move_file_safe "$child" "$epic_dir/issues/$name"
-          ;;
-      esac
-    done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+      ensure_dir "$epic_dir/issues"
+      move_file_safe "$child" "$epic_dir/issues/$name"
+    done < <(top_level_numeric_task_files "$epic_dir")
   done < <(find "$PRD_DIR" -path '*/epics/*' -type d -print0 2>/dev/null | sort -z)
 }
 
@@ -417,20 +443,21 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
     fi
 
     target_epic_dir="$PRD_DIR/$prd_name/epics/$epic_name"
-    conflict_path="$(epic_name_conflict_exists "$epic_name" "$epic_dir" || true)"
-    if [ -n "$conflict_path" ] && [ "$conflict_path" != "$target_epic_dir" ]; then
-      quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "duplicate-name-conflicts" "duplicate epic name" "$conflict_path"
-      continue
-    fi
-
-    same_target_conflict_path=""
-    if [ -d "$target_epic_dir" ]; then
-      same_target_conflict_path="$(same_target_merge_conflict_path "$epic_dir" "$target_epic_dir" || true)"
-    fi
-    if [ -n "$same_target_conflict_path" ]; then
-      quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "merge-conflicts" "same-target merge conflict" "$target_epic_dir" "$same_target_conflict_path"
-      continue
-    fi
+    classify_legacy_epic_migration "$epic_dir" "$target_epic_dir"
+    case "$MIGRATION_CLASSIFICATION" in
+      quarantine-duplicate-name)
+        quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "duplicate-name-conflicts" "duplicate epic name" "$MIGRATION_DETAIL"
+        continue
+        ;;
+      quarantine-same-target-conflict)
+        quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "merge-conflicts" "same-target merge conflict" "$target_epic_dir" "$MIGRATION_DETAIL"
+        continue
+        ;;
+      quarantine-unsupported-content)
+        quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "merge-conflicts" "unsupported legacy content" "$target_epic_dir (planned target)" "$MIGRATION_DETAIL"
+        continue
+        ;;
+    esac
 
     ensure_dir "$target_epic_dir"
 

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -86,30 +86,95 @@ move_dir_children_safe() {
   cleanup_if_empty "$src_dir"
 }
 
+next_legacy_epic_archive_dir() {
+  local legacy_root archive_kind epic_name archive_base archive_dir suffix
+  legacy_root="$1"
+  archive_kind="$2"
+  epic_name="$3"
+  archive_base="$legacy_root/.archived/$archive_kind/$epic_name"
+  archive_dir="$archive_base"
+  suffix=2
+
+  while [ -e "$archive_dir" ]; do
+    archive_dir="${archive_base}-${suffix}"
+    suffix=$((suffix + 1))
+  done
+
+  printf '%s\n' "$archive_dir"
+}
+
 quarantine_legacy_epic_conflict() {
-  local src_dir legacy_root epic_name conflict_path archive_dir
+  local src_dir legacy_root archive_kind message active_path detail archive_dir
   src_dir="$1"
   legacy_root="$2"
-  epic_name="$3"
-  conflict_path="$4"
-  archive_dir="$legacy_root/.archived/duplicate-name-conflicts/$epic_name"
-
-  if [ "$src_dir" = "$archive_dir" ]; then
-    printf 'SKIP duplicate epic quarantine already active: %s (active epic at %s)\n' "$epic_name" "$conflict_path"
-    return 0
-  fi
-
-  if [ -e "$archive_dir" ]; then
-    printf 'SKIP duplicate epic quarantine conflict: %s -> %s (active epic at %s)\n' "$src_dir" "$archive_dir" "$conflict_path"
-    return 0
-  fi
+  archive_kind="$3"
+  message="$4"
+  active_path="$5"
+  detail="${6:-}"
+  archive_dir="$(next_legacy_epic_archive_dir "$legacy_root" "$archive_kind" "$(basename "$src_dir")")"
 
   if $APPLY; then
     mkdir -p "$(dirname "$archive_dir")"
     mv "$src_dir" "$archive_dir"
-    printf 'QUARANTINED duplicate epic: %s -> %s (active epic at %s)\n' "$src_dir" "$archive_dir" "$conflict_path"
+    printf 'QUARANTINED %s: %s -> %s (active epic at %s' "$message" "$src_dir" "$archive_dir" "$active_path"
   else
-    printf 'WOULD QUARANTINE duplicate epic: %s -> %s (active epic at %s)\n' "$src_dir" "$archive_dir" "$conflict_path"
+    printf 'WOULD QUARANTINE %s: %s -> %s (active epic at %s' "$message" "$src_dir" "$archive_dir" "$active_path"
+  fi
+
+  if [ -n "$detail" ]; then
+    printf '; conflicting path %s' "$detail"
+  fi
+  printf ')\n'
+}
+
+dest_conflicts_with_src() {
+  local src dest
+  src="$1"
+  dest="$2"
+
+  [ -e "$dest" ] || return 1
+  [ -f "$dest" ] && cmp -s "$src" "$dest" && return 1
+  return 0
+}
+
+same_target_merge_conflict_path() {
+  local epic_dir target_epic_dir child name update_file relative_path target_path
+  epic_dir="$1"
+  target_epic_dir="$2"
+
+  while IFS= read -r -d '' child; do
+    name="$(basename "$child")"
+    case "$name" in
+      epic.md|github-mapping.md|execution-status.md)
+        target_path="$target_epic_dir/$name"
+        ;;
+      [0-9]*-analysis.md)
+        target_path="$target_epic_dir/$name"
+        ;;
+      *.md)
+        ccpm_is_numeric_task_filename "$name" || continue
+        target_path="$target_epic_dir/issues/$name"
+        ;;
+      *)
+        continue
+        ;;
+    esac
+
+    if dest_conflicts_with_src "$child" "$target_path"; then
+      printf '%s\n' "$target_path"
+      return 0
+    fi
+  done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+
+  if [ -d "$epic_dir/updates" ]; then
+    while IFS= read -r -d '' update_file; do
+      relative_path="${update_file#$epic_dir/updates/}"
+      target_path="$target_epic_dir/updates/$relative_path"
+      if dest_conflicts_with_src "$update_file" "$target_path"; then
+        printf '%s\n' "$target_path"
+        return 0
+      fi
+    done < <(find "$epic_dir/updates" -type f -print0 2>/dev/null | sort -z)
   fi
 }
 
@@ -236,7 +301,16 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
     target_epic_dir="$PRD_DIR/$prd_name/epics/$epic_name"
     conflict_path="$(epic_name_conflict_exists "$epic_name" "$epic_dir" || true)"
     if [ -n "$conflict_path" ] && [ "$conflict_path" != "$target_epic_dir" ]; then
-      quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "$epic_name" "$conflict_path"
+      quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "duplicate-name-conflicts" "duplicate epic name" "$conflict_path"
+      continue
+    fi
+
+    same_target_conflict_path=""
+    if [ -d "$target_epic_dir" ]; then
+      same_target_conflict_path="$(same_target_merge_conflict_path "$epic_dir" "$target_epic_dir" || true)"
+    fi
+    if [ -n "$same_target_conflict_path" ]; then
+      quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "merge-conflicts" "same-target merge conflict" "$target_epic_dir" "$same_target_conflict_path"
       continue
     fi
 
@@ -263,7 +337,7 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
     done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)
 
     cleanup_if_empty "$epic_dir"
-  done < <(find "$legacy_epic_root" -mindepth 1 -maxdepth 1 -type d ! -name archived -print0 2>/dev/null | sort -z)
+  done < <(find "$legacy_epic_root" -mindepth 1 -maxdepth 1 -type d ! -name archived ! -name .archived -print0 2>/dev/null | sort -z)
 done
 
 if ! $APPLY; then

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
+
+PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" --ensure)"
+APPLY=false
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=true
+fi
+
+ensure_dir() {
+  local path
+  path="$1"
+  if [ -d "$path" ]; then
+    return 0
+  fi
+  if $APPLY; then
+    mkdir -p "$path"
+    printf 'CREATED %s\n' "$path"
+  else
+    printf 'WOULD CREATE %s\n' "$path"
+  fi
+}
+
+cleanup_if_empty() {
+  local path
+  path="$1"
+  if $APPLY && [ -d "$path" ] && [ -z "$(find "$path" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+    rmdir "$path"
+    printf 'REMOVED EMPTY %s\n' "$path"
+  fi
+}
+
+move_file_safe() {
+  local src dest
+  src="$1"
+  dest="$2"
+  [ -f "$src" ] || return 0
+
+  if [ ! -e "$dest" ]; then
+    if $APPLY; then
+      mkdir -p "$(dirname "$dest")"
+      mv "$src" "$dest"
+      printf 'MOVED %s -> %s\n' "$src" "$dest"
+    else
+      printf 'WOULD MOVE %s -> %s\n' "$src" "$dest"
+    fi
+    return 0
+  fi
+
+  if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+    if $APPLY; then
+      rm "$src"
+      printf 'REMOVED DUPLICATE %s\n' "$src"
+    else
+      printf 'WOULD REMOVE DUPLICATE %s\n' "$src"
+    fi
+    return 0
+  fi
+
+  printf 'SKIP conflict: %s -> %s\n' "$src" "$dest"
+}
+
+move_dir_children_safe() {
+  local src_dir dest_dir child dest_child
+  src_dir="$1"
+  dest_dir="$2"
+  [ -d "$src_dir" ] || return 0
+
+  ensure_dir "$dest_dir"
+
+  while IFS= read -r -d '' child; do
+    dest_child="$dest_dir/$(basename "$child")"
+    if [ -d "$child" ]; then
+      move_dir_children_safe "$child" "$dest_child"
+    else
+      move_file_safe "$child" "$dest_child"
+    fi
+  done < <(find "$src_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)
+
+  cleanup_if_empty "$src_dir"
+}
+
+normalize_prd_reference() {
+  local ref configured_prd_dir
+  ref="$1"
+  configured_prd_dir="$2"
+
+  ref="${ref%\"}"
+  ref="${ref#\"}"
+  ref="${ref%\'}"
+  ref="${ref#\'}"
+  ref="${ref#./}"
+  ref="${ref#\$\{PRD_DIR\}/}"
+  ref="${ref#\$PRD_DIR/}"
+  [ -n "$configured_prd_dir" ] && ref="${ref#$configured_prd_dir/}"
+  ref="${ref#.claude/prds/}"
+  ref="${ref#.cursor/ccpm/prds/}"
+
+  if [ "$(basename "$ref")" = "prd.md" ]; then
+    basename "$(dirname "$ref")"
+  elif [[ "$ref" == *.md ]]; then
+    basename "$ref" .md
+  else
+    basename "$ref"
+  fi
+}
+
+resolve_prd_name_for_legacy_epic() {
+  local epic_dir prd_ref prd_name prd_path
+  epic_dir="$1"
+
+  prd_ref="$(grep '^prd:' "$epic_dir/epic.md" 2>/dev/null | head -1 | sed 's/^prd:[[:space:]]*//')"
+  if [ -n "$prd_ref" ]; then
+    prd_name="$(normalize_prd_reference "$prd_ref" "$PRD_DIR")"
+    if [ -n "$prd_name" ]; then
+      printf '%s\n' "$prd_name"
+      return 0
+    fi
+  fi
+
+  prd_path="$("$SCRIPT_DIR/resolve-prd-path.sh" "$(basename "$epic_dir")" 2>/dev/null || true)"
+  if [ -n "$prd_path" ]; then
+    ccpm_prd_name_from_path "$prd_path"
+    return 0
+  fi
+
+  return 1
+}
+
+echo "CCPM nested layout migration"
+echo "Mode: $([ "$APPLY" = true ] && echo apply || echo dry-run)"
+echo "Target PRD root: $PRD_DIR"
+echo ""
+
+while IFS= read -r -d '' prd_file; do
+  prd_name="$(basename "$prd_file" .md)"
+  move_file_safe "$prd_file" "$PRD_DIR/$prd_name/prd.md"
+done < <(find "$PRD_DIR" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+
+for legacy_prd_root in ".claude/prds" ".cursor/ccpm/prds"; do
+  [ -d "$legacy_prd_root" ] || continue
+  while IFS= read -r -d '' prd_file; do
+    prd_name="$(basename "$prd_file" .md)"
+    move_file_safe "$prd_file" "$PRD_DIR/$prd_name/prd.md"
+  done < <(find "$legacy_prd_root" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+  cleanup_if_empty "$legacy_prd_root"
+done
+
+for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
+  [ -d "$legacy_epic_root" ] || continue
+  while IFS= read -r -d '' epic_dir; do
+    epic_name="$(basename "$epic_dir")"
+    prd_name="$(resolve_prd_name_for_legacy_epic "$epic_dir" 2>/dev/null || true)"
+    if [ -z "$prd_name" ]; then
+      printf 'SKIP unmatched legacy epic: %s\n' "$epic_name"
+      continue
+    fi
+
+    target_epic_dir="$PRD_DIR/$prd_name/epics/$epic_name"
+    ensure_dir "$target_epic_dir"
+    ensure_dir "$target_epic_dir/issues"
+
+    while IFS= read -r -d '' child; do
+      name="$(basename "$child")"
+      case "$name" in
+        epic.md|github-mapping.md|execution-status.md)
+          move_file_safe "$child" "$target_epic_dir/$name"
+          ;;
+        updates)
+          move_dir_children_safe "$child" "$target_epic_dir/updates"
+          ;;
+        [0-9]*.md)
+          move_file_safe "$child" "$target_epic_dir/issues/$name"
+          ;;
+        [0-9]*-analysis.md)
+          move_file_safe "$child" "$target_epic_dir/$name"
+          ;;
+      esac
+    done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)
+
+    cleanup_if_empty "$epic_dir"
+  done < <(find "$legacy_epic_root" -mindepth 1 -maxdepth 1 -type d ! -name archived -print0 2>/dev/null | sort -z)
+done
+
+if ! $APPLY; then
+  echo ""
+  echo "Run with --apply to perform the migration."
+fi

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -67,10 +67,16 @@ move_file_safe() {
 }
 
 move_dir_children_safe() {
-  local src_dir dest_dir child dest_child
+  local src_dir dest_dir child dest_child first_child
   src_dir="$1"
   dest_dir="$2"
   [ -d "$src_dir" ] || return 0
+
+  first_child="$(find "$src_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)"
+  if [ -z "$first_child" ]; then
+    cleanup_if_empty "$src_dir"
+    return 0
+  fi
 
   ensure_dir "$dest_dir"
 
@@ -137,29 +143,119 @@ dest_conflicts_with_src() {
   return 0
 }
 
+path_shape_conflict_path() {
+  local dest root current relative remainder
+  dest="$1"
+  root="$2"
+
+  current="$(dirname "$dest")"
+  relative="${current#"$root"}"
+  relative="${relative#/}"
+
+  if [ -n "$relative" ]; then
+    remainder="$root"
+    IFS='/' read -r -a _ccpm_segments <<< "$relative"
+    for _ccpm_segment in "${_ccpm_segments[@]}"; do
+      remainder="$remainder/$_ccpm_segment"
+      if [ -e "$remainder" ] && [ ! -d "$remainder" ]; then
+        printf '%s\n' "$remainder"
+        unset _ccpm_segments _ccpm_segment
+        return 0
+      fi
+    done
+    unset _ccpm_segments _ccpm_segment
+  fi
+
+  if [ -e "$dest" ] && [ ! -f "$dest" ]; then
+    printf '%s\n' "$dest"
+    return 0
+  fi
+
+  return 1
+}
+
+mapped_destination_for_legacy_child() {
+  local child target_epic_dir name relative_path
+  child="$1"
+  target_epic_dir="$2"
+  name="$(basename "$child")"
+
+  case "$name" in
+    epic.md|github-mapping.md|execution-status.md)
+      printf '%s\n' "$target_epic_dir/$name"
+      ;;
+    [0-9]*-analysis.md)
+      printf '%s\n' "$target_epic_dir/$name"
+      ;;
+    *.md)
+      ccpm_is_numeric_task_filename "$name" || return 1
+      printf '%s\n' "$target_epic_dir/issues/$name"
+      ;;
+    updates)
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+unsupported_legacy_epic_entry() {
+  local epic_dir entry name
+  epic_dir="$1"
+
+  while IFS= read -r -d '' entry; do
+    name="$(basename "$entry")"
+    if [ -d "$entry" ]; then
+      [ "$name" = "updates" ] && continue
+      printf '%s\n' "$entry"
+      return 0
+    fi
+
+    case "$name" in
+      epic.md|github-mapping.md|execution-status.md|[0-9]*-analysis.md)
+        continue
+        ;;
+      *.md)
+        ccpm_is_numeric_task_filename "$name" && continue
+        printf '%s\n' "$entry"
+        return 0
+        ;;
+      *)
+        printf '%s\n' "$entry"
+        return 0
+        ;;
+    esac
+  done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)
+
+  return 1
+}
+
 same_target_merge_conflict_path() {
-  local epic_dir target_epic_dir child name update_file relative_path target_path
+  local epic_dir target_epic_dir child update_entry relative_path target_path unsupported_path shape_conflict
   epic_dir="$1"
   target_epic_dir="$2"
 
-  while IFS= read -r -d '' child; do
-    name="$(basename "$child")"
-    case "$name" in
-      epic.md|github-mapping.md|execution-status.md)
-        target_path="$target_epic_dir/$name"
-        ;;
-      [0-9]*-analysis.md)
-        target_path="$target_epic_dir/$name"
-        ;;
-      *.md)
-        ccpm_is_numeric_task_filename "$name" || continue
-        target_path="$target_epic_dir/issues/$name"
-        ;;
-      *)
-        continue
-        ;;
-    esac
+  unsupported_path="$(unsupported_legacy_epic_entry "$epic_dir" || true)"
+  if [ -n "$unsupported_path" ]; then
+    printf '%s\n' "$unsupported_path"
+    return 0
+  fi
 
+  if [ -f "$epic_dir/epic.md" ] && path_shape_conflict_path "$target_epic_dir/issues" "$target_epic_dir" >/dev/null; then
+    path_shape_conflict_path "$target_epic_dir/issues" "$target_epic_dir"
+    return 0
+  fi
+
+  while IFS= read -r -d '' child; do
+    target_path="$(mapped_destination_for_legacy_child "$child" "$target_epic_dir" || true)"
+    [ -n "$target_path" ] || continue
+
+    shape_conflict="$(path_shape_conflict_path "$target_path" "$target_epic_dir" || true)"
+    if [ -n "$shape_conflict" ]; then
+      printf '%s\n' "$shape_conflict"
+      return 0
+    fi
     if dest_conflicts_with_src "$child" "$target_path"; then
       printf '%s\n' "$target_path"
       return 0
@@ -167,14 +263,25 @@ same_target_merge_conflict_path() {
   done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
 
   if [ -d "$epic_dir/updates" ]; then
-    while IFS= read -r -d '' update_file; do
-      relative_path="${update_file#$epic_dir/updates/}"
+    shape_conflict="$(path_shape_conflict_path "$target_epic_dir/updates" "$target_epic_dir" || true)"
+    if [ -n "$shape_conflict" ]; then
+      printf '%s\n' "$shape_conflict"
+      return 0
+    fi
+
+    while IFS= read -r -d '' update_entry; do
+      relative_path="${update_entry#$epic_dir/updates/}"
       target_path="$target_epic_dir/updates/$relative_path"
-      if dest_conflicts_with_src "$update_file" "$target_path"; then
+      shape_conflict="$(path_shape_conflict_path "$target_path" "$target_epic_dir" || true)"
+      if [ -n "$shape_conflict" ]; then
+        printf '%s\n' "$shape_conflict"
+        return 0
+      fi
+      if dest_conflicts_with_src "$update_entry" "$target_path"; then
         printf '%s\n' "$target_path"
         return 0
       fi
-    done < <(find "$epic_dir/updates" -type f -print0 2>/dev/null | sort -z)
+    done < <(find "$epic_dir/updates" -mindepth 1 -print0 2>/dev/null | sort -z)
   fi
 }
 
@@ -196,13 +303,23 @@ epic_name_conflict_exists() {
 }
 
 normalize_nested_epic_dirs() {
-  local epic_dir child name
+  local epic_dir child name issue_conflict
 
   [ -d "$PRD_DIR" ] || return 0
 
   while IFS= read -r -d '' epic_dir; do
     [ -f "$epic_dir/epic.md" ] || continue
-    ensure_dir "$epic_dir/issues"
+
+    issue_conflict=""
+    while IFS= read -r -d '' child; do
+      name="$(basename "$child")"
+      ccpm_is_numeric_task_filename "$name" || continue
+      issue_conflict="$(path_shape_conflict_path "$epic_dir/issues/$name" "$epic_dir" || true)"
+      if [ -n "$issue_conflict" ]; then
+        printf 'ERROR nested normalization conflict: %s requires directory-compatible path for %s\n' "$epic_dir" "$issue_conflict" >&2
+        return 1
+      fi
+    done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
 
     while IFS= read -r -d '' child; do
       name="$(basename "$child")"
@@ -213,6 +330,7 @@ normalize_nested_epic_dirs() {
           ;;
         *.md)
           ccpm_is_numeric_task_filename "$name" || continue
+          ensure_dir "$epic_dir/issues"
           move_file_safe "$child" "$epic_dir/issues/$name"
           ;;
       esac
@@ -315,7 +433,6 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
     fi
 
     ensure_dir "$target_epic_dir"
-    ensure_dir "$target_epic_dir/issues"
 
     while IFS= read -r -d '' child; do
       name="$(basename "$child")"
@@ -331,6 +448,7 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
           ;;
         *.md)
           ccpm_is_numeric_task_filename "$name" || continue
+          ensure_dir "$target_epic_dir/issues"
           move_file_safe "$child" "$target_epic_dir/issues/$name"
           ;;
       esac

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -86,6 +86,40 @@ move_dir_children_safe() {
   cleanup_if_empty "$src_dir"
 }
 
+epic_name_conflict_exists() {
+  local epic_name current_path epic_dir
+  epic_name="$1"
+  current_path="$2"
+
+  while IFS= read -r epic_dir; do
+    [ -n "$epic_dir" ] || continue
+    [ "$epic_dir" = "$current_path" ] && continue
+    if [ "$(basename "$epic_dir")" = "$epic_name" ]; then
+      printf '%s\n' "$epic_dir"
+      return 0
+    fi
+  done < <(ccpm_list_epic_dirs)
+
+  return 1
+}
+
+normalize_nested_epic_dirs() {
+  local epic_dir child name
+
+  [ -d "$PRD_DIR" ] || return 0
+
+  while IFS= read -r -d '' epic_dir; do
+    [ -f "$epic_dir/epic.md" ] || continue
+    ensure_dir "$epic_dir/issues"
+
+    while IFS= read -r -d '' child; do
+      name="$(basename "$child")"
+      ccpm_is_numeric_task_filename "$name" || continue
+      move_file_safe "$child" "$epic_dir/issues/$name"
+    done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
+  done < <(find "$PRD_DIR" -path '*/epics/*' -type d -print0 2>/dev/null | sort -z)
+}
+
 normalize_prd_reference() {
   local ref configured_prd_dir
   ref="$1"
@@ -138,6 +172,8 @@ echo "Mode: $([ "$APPLY" = true ] && echo apply || echo dry-run)"
 echo "Target PRD root: $PRD_DIR"
 echo ""
 
+normalize_nested_epic_dirs
+
 while IFS= read -r -d '' prd_file; do
   prd_name="$(basename "$prd_file" .md)"
   move_file_safe "$prd_file" "$PRD_DIR/$prd_name/prd.md"
@@ -158,11 +194,17 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
     epic_name="$(basename "$epic_dir")"
     prd_name="$(resolve_prd_name_for_legacy_epic "$epic_dir" 2>/dev/null || true)"
     if [ -z "$prd_name" ]; then
-      printf 'SKIP unmatched legacy epic: %s\n' "$epic_name"
+      printf 'SKIP unmatched legacy epic: %s (no prd: link and no matching PRD name; add prd: metadata or create/move the target PRD first)\n' "$epic_name"
       continue
     fi
 
     target_epic_dir="$PRD_DIR/$prd_name/epics/$epic_name"
+    conflict_path="$(epic_name_conflict_exists "$epic_name" "$epic_dir" || true)"
+    if [ -n "$conflict_path" ] && [ "$conflict_path" != "$target_epic_dir" ]; then
+      printf 'SKIP duplicate epic name: %s already exists at %s\n' "$epic_name" "$conflict_path"
+      continue
+    fi
+
     ensure_dir "$target_epic_dir"
     ensure_dir "$target_epic_dir/issues"
 
@@ -175,7 +217,8 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
         updates)
           move_dir_children_safe "$child" "$target_epic_dir/updates"
           ;;
-        [0-9]*.md)
+        *.md)
+          ccpm_is_numeric_task_filename "$name" || continue
           move_file_safe "$child" "$target_epic_dir/issues/$name"
           ;;
         [0-9]*-analysis.md)

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -143,7 +143,8 @@ normalize_nested_epic_dirs() {
       name="$(basename "$child")"
       case "$name" in
         [0-9]*-analysis.md)
-          move_file_safe "$child" "$epic_dir/$name"
+          # Old nested layouts already keep analysis files at epic root.
+          continue
           ;;
         *.md)
           ccpm_is_numeric_task_filename "$name" || continue

--- a/skill/ccpm/references/scripts/migrate-layout.sh
+++ b/skill/ccpm/references/scripts/migrate-layout.sh
@@ -86,6 +86,33 @@ move_dir_children_safe() {
   cleanup_if_empty "$src_dir"
 }
 
+quarantine_legacy_epic_conflict() {
+  local src_dir legacy_root epic_name conflict_path archive_dir
+  src_dir="$1"
+  legacy_root="$2"
+  epic_name="$3"
+  conflict_path="$4"
+  archive_dir="$legacy_root/.archived/duplicate-name-conflicts/$epic_name"
+
+  if [ "$src_dir" = "$archive_dir" ]; then
+    printf 'SKIP duplicate epic quarantine already active: %s (active epic at %s)\n' "$epic_name" "$conflict_path"
+    return 0
+  fi
+
+  if [ -e "$archive_dir" ]; then
+    printf 'SKIP duplicate epic quarantine conflict: %s -> %s (active epic at %s)\n' "$src_dir" "$archive_dir" "$conflict_path"
+    return 0
+  fi
+
+  if $APPLY; then
+    mkdir -p "$(dirname "$archive_dir")"
+    mv "$src_dir" "$archive_dir"
+    printf 'QUARANTINED duplicate epic: %s -> %s (active epic at %s)\n' "$src_dir" "$archive_dir" "$conflict_path"
+  else
+    printf 'WOULD QUARANTINE duplicate epic: %s -> %s (active epic at %s)\n' "$src_dir" "$archive_dir" "$conflict_path"
+  fi
+}
+
 epic_name_conflict_exists() {
   local epic_name current_path epic_dir
   epic_name="$1"
@@ -114,8 +141,15 @@ normalize_nested_epic_dirs() {
 
     while IFS= read -r -d '' child; do
       name="$(basename "$child")"
-      ccpm_is_numeric_task_filename "$name" || continue
-      move_file_safe "$child" "$epic_dir/issues/$name"
+      case "$name" in
+        [0-9]*-analysis.md)
+          move_file_safe "$child" "$epic_dir/$name"
+          ;;
+        *.md)
+          ccpm_is_numeric_task_filename "$name" || continue
+          move_file_safe "$child" "$epic_dir/issues/$name"
+          ;;
+      esac
     done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 2>/dev/null | sort -z)
   done < <(find "$PRD_DIR" -path '*/epics/*' -type d -print0 2>/dev/null | sort -z)
 }
@@ -201,7 +235,7 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
     target_epic_dir="$PRD_DIR/$prd_name/epics/$epic_name"
     conflict_path="$(epic_name_conflict_exists "$epic_name" "$epic_dir" || true)"
     if [ -n "$conflict_path" ] && [ "$conflict_path" != "$target_epic_dir" ]; then
-      printf 'SKIP duplicate epic name: %s already exists at %s\n' "$epic_name" "$conflict_path"
+      quarantine_legacy_epic_conflict "$epic_dir" "$legacy_epic_root" "$epic_name" "$conflict_path"
       continue
     fi
 
@@ -217,12 +251,12 @@ for legacy_epic_root in ".claude/epics" ".cursor/ccpm/epics"; do
         updates)
           move_dir_children_safe "$child" "$target_epic_dir/updates"
           ;;
+        [0-9]*-analysis.md)
+          move_file_safe "$child" "$target_epic_dir/$name"
+          ;;
         *.md)
           ccpm_is_numeric_task_filename "$name" || continue
           move_file_safe "$child" "$target_epic_dir/issues/$name"
-          ;;
-        [0-9]*-analysis.md)
-          move_file_safe "$child" "$target_epic_dir/$name"
           ;;
       esac
     done < <(find "$epic_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)

--- a/skill/ccpm/references/scripts/next.sh
+++ b/skill/ccpm/references/scripts/next.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
+
 echo "Getting status..."
 echo ""
 echo ""
@@ -10,13 +16,11 @@ echo ""
 # Find tasks that are open and have no dependencies or whose dependencies are closed
 found=0
 
-for epic_dir in .claude/epics/*/; do
-  [ -d "$epic_dir" ] || continue
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
   epic_name=$(basename "$epic_dir")
 
-  for task_file in "$epic_dir"/[0-9]*.md; do
-    [ -f "$task_file" ] || continue
-
+  while IFS= read -r task_file; do
     # Check if task is open
     status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
     if [ "$status" != "open" ] && [ -n "$status" ]; then
@@ -32,8 +36,23 @@ for epic_dir in .claude/epics/*/; do
       deps=""
     fi
 
-    # If no dependencies or empty, task is available
-    if [ -z "$deps" ] || [ "$deps" = "depends_on:" ]; then
+    ready=true
+    if [ -n "$deps" ] && [ "$deps" != "depends_on:" ]; then
+      for dep in $(echo "$deps" | sed 's/,/ /g'); do
+        dep_file="$(ccpm_task_file_for_epic_issue "$epic_dir" "$dep" 2>/dev/null || true)"
+        if [ ! -f "$dep_file" ]; then
+          ready=false
+          break
+        fi
+        dep_status=$(grep "^status:" "$dep_file" | head -1 | sed 's/^status: *//')
+        if [ "$dep_status" != "closed" ] && [ "$dep_status" != "completed" ]; then
+          ready=false
+          break
+        fi
+      done
+    fi
+
+    if $ready; then
       task_name=$(grep "^name:" "$task_file" | head -1 | sed 's/^name: *//')
       task_num=$(basename "$task_file" .md)
       parallel=$(grep "^parallel:" "$task_file" | head -1 | sed 's/^parallel: *//')
@@ -44,8 +63,8 @@ for epic_dir in .claude/epics/*/; do
       echo ""
       ((found++))
     fi
-  done
-done
+  done < <(ccpm_list_task_files_for_epic "$epic_dir")
+done < <(ccpm_list_epic_dirs)
 
 if [ $found -eq 0 ]; then
   echo "No available tasks found."

--- a/skill/ccpm/references/scripts/prd-list.sh
+++ b/skill/ccpm/references/scripts/prd-list.sh
@@ -1,12 +1,13 @@
-# !/bin/bash
-# Check if PRD directory exists
-if [ ! -d ".claude/prds" ]; then
-  echo "📁 No PRD directory found. Ask CCPM: I want to build <feature-name>"
-  exit 0
-fi
+#!/bin/bash
+set -uo pipefail
 
-# Check for PRD files
-if ! ls .claude/prds/*.md >/dev/null 2>&1; then
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
+
+PRD_DIR="$(ccpm_resolve_prd_dir --allow-missing 2>/dev/null || true)"
+
+if [ -z "$(ccpm_list_prd_files)" ]; then
   echo "📁 No PRDs found. Ask CCPM: I want to build <feature-name>"
   exit 0
 fi
@@ -28,54 +29,51 @@ echo ""
 
 # Display by status groups
 echo "🔍 Backlog PRDs:"
-for file in .claude/prds/*.md; do
-  [ -f "$file" ] || continue
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
   status=$(grep "^status:" "$file" | head -1 | sed 's/^status: *//')
   if [ "$status" = "backlog" ] || [ "$status" = "draft" ] || [ -z "$status" ]; then
     name=$(grep "^name:" "$file" | head -1 | sed 's/^name: *//')
     desc=$(grep "^description:" "$file" | head -1 | sed 's/^description: *//')
-    [ -z "$name" ] && name=$(basename "$file" .md)
+    [ -z "$name" ] && name=$(ccpm_prd_name_from_path "$file")
     [ -z "$desc" ] && desc="No description"
-    # echo "   📋 $name - $desc"
     echo "   📋 $file - $desc"
     ((backlog_count++))
   fi
   ((total_count++))
-done
+done < <(ccpm_list_prd_files)
 [ $backlog_count -eq 0 ] && echo "   (none)"
 
 echo ""
 echo "🔄 In-Progress PRDs:"
-for file in .claude/prds/*.md; do
-  [ -f "$file" ] || continue
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
   status=$(grep "^status:" "$file" | head -1 | sed 's/^status: *//')
   if [ "$status" = "in-progress" ] || [ "$status" = "active" ]; then
     name=$(grep "^name:" "$file" | head -1 | sed 's/^name: *//')
     desc=$(grep "^description:" "$file" | head -1 | sed 's/^description: *//')
-    [ -z "$name" ] && name=$(basename "$file" .md)
+    [ -z "$name" ] && name=$(ccpm_prd_name_from_path "$file")
     [ -z "$desc" ] && desc="No description"
-    # echo "   📋 $name - $desc"
     echo "   📋 $file - $desc"
     ((in_progress_count++))
   fi
-done
+done < <(ccpm_list_prd_files)
 [ $in_progress_count -eq 0 ] && echo "   (none)"
 
 echo ""
 echo "✅ Implemented PRDs:"
-for file in .claude/prds/*.md; do
-  [ -f "$file" ] || continue
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
   status=$(grep "^status:" "$file" | head -1 | sed 's/^status: *//')
   if [ "$status" = "implemented" ] || [ "$status" = "completed" ] || [ "$status" = "done" ]; then
     name=$(grep "^name:" "$file" | head -1 | sed 's/^name: *//')
     desc=$(grep "^description:" "$file" | head -1 | sed 's/^description: *//')
-    [ -z "$name" ] && name=$(basename "$file" .md)
+    [ -z "$name" ] && name=$(ccpm_prd_name_from_path "$file")
     [ -z "$desc" ] && desc="No description"
-    # echo "   📋 $name - $desc"
     echo "   📋 $file - $desc"
     ((implemented_count++))
   fi
-done
+done < <(ccpm_list_prd_files)
 [ $implemented_count -eq 0 ] && echo "   (none)"
 
 # Display summary

--- a/skill/ccpm/references/scripts/prd-status.sh
+++ b/skill/ccpm/references/scripts/prd-status.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 echo "📄 PRD Status Report"
 echo "===================="
 echo ""
 
-if [ ! -d ".claude/prds" ]; then
-  echo "No PRD directory found."
-  exit 0
-fi
+PRD_DIR="$(ccpm_resolve_prd_dir --allow-missing 2>/dev/null || true)"
 
-total=$(ls .claude/prds/*.md 2>/dev/null | wc -l)
+total=$(ccpm_list_prd_files | wc -l | tr -d '[:space:]')
 [ $total -eq 0 ] && echo "No PRDs found." && exit 0
 
 # Count by status
@@ -17,8 +19,8 @@ backlog=0
 in_progress=0
 implemented=0
 
-for file in .claude/prds/*.md; do
-  [ -f "$file" ] || continue
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
   status=$(grep "^status:" "$file" | head -1 | sed 's/^status: *//')
 
   case "$status" in
@@ -27,7 +29,7 @@ for file in .claude/prds/*.md; do
     implemented|completed|done) ((implemented++)) ;;
     *) ((backlog++)) ;;
   esac
-done
+done < <(ccpm_list_prd_files)
 
 echo "Getting status..."
 echo ""
@@ -47,9 +49,9 @@ echo "  Total PRDs: $total"
 # Recent activity
 echo ""
 echo "📅 Recent PRDs (last 5 modified):"
-ls -t .claude/prds/*.md 2>/dev/null | head -5 | while read file; do
+ccpm_list_prd_files | xargs ls -t 2>/dev/null | head -5 | while read -r file; do
   name=$(grep "^name:" "$file" | head -1 | sed 's/^name: *//')
-  [ -z "$name" ] && name=$(basename "$file" .md)
+  [ -z "$name" ] && name=$(ccpm_prd_name_from_path "$file")
   echo "  • $name"
 done
 

--- a/skill/ccpm/references/scripts/resolve-epic-dir.sh
+++ b/skill/ccpm/references/scripts/resolve-epic-dir.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" --allow-missing 2>/dev/null || true)"
+
+find_matching_epics() {
+  local epic_name prd_dir epic_dir legacy_root
+  epic_name="$1"
+
+  prd_dir="$("$SCRIPT_DIR/resolve-prd-dir.sh" --allow-missing 2>/dev/null || true)"
+  if [ -n "$prd_dir" ] && [ -d "$prd_dir" ]; then
+    while IFS= read -r -d '' epic_dir; do
+      [ -f "$epic_dir/epic.md" ] || continue
+      printf '%s\n' "$epic_dir"
+    done < <(find "$prd_dir" -path "*/epics/$epic_name" -type d -print0 2>/dev/null | sort -z)
+  fi
+
+  for legacy_root in ".claude/epics" ".cursor/ccpm/epics"; do
+    if [ -f "$legacy_root/$epic_name/epic.md" ]; then
+      printf '%s\n' "$legacy_root/$epic_name"
+    fi
+  done
+}
+
+if [ "${1:-}" = "--ensure" ]; then
+  if [ $# -ne 3 ]; then
+    echo "Usage: $0 --ensure <prd_name> <epic_name>" >&2
+    exit 1
+  fi
+  PRD_NAME="$2"
+  EPIC_NAME="$3"
+  [ -n "$PRD_DIR" ] || PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" --ensure)"
+  target_dir="$PRD_DIR/$PRD_NAME/epics/$EPIC_NAME"
+  existing_matches="$(find_matching_epics "$EPIC_NAME")"
+  if [ -n "$existing_matches" ]; then
+    while IFS= read -r existing_dir; do
+      [ -n "$existing_dir" ] || continue
+      if [ "$existing_dir" != "$target_dir" ]; then
+        echo "❌ Duplicate epic name: $EPIC_NAME already exists at $existing_dir" >&2
+        exit 1
+      fi
+    done <<< "$existing_matches"
+  fi
+  mkdir -p "$PRD_DIR/$PRD_NAME/epics/$EPIC_NAME/issues"
+  printf '%s\n' "$PRD_DIR/$PRD_NAME/epics/$EPIC_NAME"
+  exit 0
+fi
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <epic_name>" >&2
+  exit 1
+fi
+
+EPIC_NAME="$1"
+matches="$(find_matching_epics "$EPIC_NAME")"
+match_count="$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+
+if [ "$match_count" -eq 1 ]; then
+  printf '%s\n' "$matches" | sed '/^$/d' | head -1
+  exit 0
+fi
+
+if [ "$match_count" -gt 1 ]; then
+  echo "❌ Ambiguous epic name: $EPIC_NAME" >&2
+  printf '%s\n' "$matches" | sed '/^$/d' >&2
+  exit 1
+fi
+
+echo "❌ Epic not found: $EPIC_NAME" >&2
+exit 1

--- a/skill/ccpm/references/scripts/resolve-issue-file.sh
+++ b/skill/ccpm/references/scripts/resolve-issue-file.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <issue_number>" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" 2>/dev/null || true)"
+
+if [ -n "$PRD_DIR" ] && [ -d "$PRD_DIR" ]; then
+  while IFS= read -r -d '' issue_file; do
+    printf '%s\n' "$issue_file"
+    exit 0
+  done < <(find "$PRD_DIR" -path "*/issues/$ISSUE_NUM.md" -type f -print0 2>/dev/null | sort -z)
+fi
+
+for legacy_root in ".claude/epics" ".cursor/ccpm/epics"; do
+  while IFS= read -r -d '' legacy_file; do
+    printf '%s\n' "$legacy_file"
+    exit 0
+  done < <(find "$legacy_root" -mindepth 2 -maxdepth 2 -name "$ISSUE_NUM.md" -type f -print0 2>/dev/null | sort -z)
+done
+
+echo "❌ Issue file not found: $ISSUE_NUM" >&2
+exit 1

--- a/skill/ccpm/references/scripts/resolve-issue-file.sh
+++ b/skill/ccpm/references/scripts/resolve-issue-file.sh
@@ -9,13 +9,18 @@ fi
 
 ISSUE_NUM="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" 2>/dev/null || true)"
+PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" --allow-missing 2>/dev/null || true)"
 
 if [ -n "$PRD_DIR" ] && [ -d "$PRD_DIR" ]; then
   while IFS= read -r -d '' issue_file; do
     printf '%s\n' "$issue_file"
     exit 0
   done < <(find "$PRD_DIR" -path "*/issues/$ISSUE_NUM.md" -type f -print0 2>/dev/null | sort -z)
+
+  while IFS= read -r -d '' issue_file; do
+    printf '%s\n' "$issue_file"
+    exit 0
+  done < <(find "$PRD_DIR" -path "*/epics/*/$ISSUE_NUM.md" -type f -print0 2>/dev/null | sort -z)
 fi
 
 for legacy_root in ".claude/epics" ".cursor/ccpm/epics"; do

--- a/skill/ccpm/references/scripts/resolve-prd-dir.sh
+++ b/skill/ccpm/references/scripts/resolve-prd-dir.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CFG="$ROOT/.claude/.ccpmrc"
+
+if [ -f "$CFG" ]; then
+  # shellcheck disable=SC1090
+  set -a
+  . "$CFG" 2>/dev/null || true
+  set +a
+fi
+
+PRD_DIR="${CCPM_PRD_DIR:-${PRD_DIR:-docs/prds}}"
+
+case "$PRD_DIR" in
+  ./*) PRD_DIR="${PRD_DIR#./}" ;;
+esac
+PRD_DIR="${PRD_DIR%/}"
+
+if [[ "$PRD_DIR" == *".."* ]]; then
+  echo "❌ Security Error: PRD directory path cannot contain '..'" >&2
+  exit 1
+fi
+
+if [[ "$PRD_DIR" == /* ]]; then
+  echo "❌ Security Error: PRD directory must be relative to project root" >&2
+  exit 1
+fi
+
+if [ "${1:-}" = "--ensure" ]; then
+  mkdir -p "$ROOT/$PRD_DIR"
+elif [ "${1:-}" = "--allow-missing" ]; then
+  :
+elif [ ! -d "$ROOT/$PRD_DIR" ]; then
+  echo "❌ PRD directory not found: $PRD_DIR (absolute: $ROOT/$PRD_DIR)" >&2
+  exit 1
+fi
+
+printf '%s\n' "$PRD_DIR"

--- a/skill/ccpm/references/scripts/resolve-prd-path.sh
+++ b/skill/ccpm/references/scripts/resolve-prd-path.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <prd_name>" >&2
+  exit 1
+fi
+
+PRD_NAME="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRD_DIR="$("$SCRIPT_DIR/resolve-prd-dir.sh" 2>/dev/null || true)"
+
+if [ -n "$PRD_DIR" ] && [ -f "$PRD_DIR/$PRD_NAME/prd.md" ]; then
+  printf '%s\n' "$PRD_DIR/$PRD_NAME/prd.md"
+  exit 0
+fi
+
+if [ -n "$PRD_DIR" ] && [ -f "$PRD_DIR/$PRD_NAME.md" ]; then
+  printf '%s\n' "$PRD_DIR/$PRD_NAME.md"
+  exit 0
+fi
+
+for legacy_root in ".claude/prds" ".cursor/ccpm/prds"; do
+  if [ -f "$legacy_root/$PRD_NAME.md" ]; then
+    printf '%s\n' "$legacy_root/$PRD_NAME.md"
+    exit 0
+  fi
+done
+
+echo "❌ PRD not found: $PRD_NAME" >&2
+exit 1

--- a/skill/ccpm/references/scripts/search.sh
+++ b/skill/ccpm/references/scripts/search.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 query="$1"
 
@@ -17,12 +22,12 @@ echo "================================"
 echo ""
 
 # Search in PRDs
-if [ -d ".claude/prds" ]; then
+if [ -n "$(ccpm_list_prd_files)" ]; then
   echo "📄 PRDs:"
-  results=$(grep -l -i "$query" .claude/prds/*.md 2>/dev/null)
+  results="$(ccpm_list_prd_files | xargs grep -l -i "$query" 2>/dev/null || true)"
   if [ -n "$results" ]; then
     for file in $results; do
-      name=$(basename "$file" .md)
+      name=$(ccpm_prd_name_from_path "$file")
       matches=$(grep -c -i "$query" "$file")
       echo "  • $name ($matches matches)"
     done
@@ -33,9 +38,9 @@ if [ -d ".claude/prds" ]; then
 fi
 
 # Search in Epics
-if [ -d ".claude/epics" ]; then
+if [ -n "$(ccpm_list_epic_dirs)" ]; then
   echo "📚 Epics:"
-  results=$(find .claude/epics -name "epic.md" -exec grep -l -i "$query" {} \; 2>/dev/null)
+  results=$(ccpm_list_epic_dirs | while IFS= read -r dir; do grep -l -i "$query" "$dir/epic.md" 2>/dev/null || true; done)
   if [ -n "$results" ]; then
     for file in $results; do
       epic_name=$(basename $(dirname "$file"))
@@ -49,12 +54,12 @@ if [ -d ".claude/epics" ]; then
 fi
 
 # Search in Tasks
-if [ -d ".claude/epics" ]; then
+if [ -n "$(ccpm_list_task_files)" ]; then
   echo "📝 Tasks:"
-  results=$(find .claude/epics -name "[0-9]*.md" -exec grep -l -i "$query" {} \; 2>/dev/null | head -10)
+  results=$(ccpm_list_task_files | xargs grep -l -i "$query" 2>/dev/null | head -10 || true)
   if [ -n "$results" ]; then
     for file in $results; do
-      epic_name=$(basename $(dirname "$file"))
+      epic_name=$(basename "$(ccpm_epic_dir_from_task_file "$file")")
       task_num=$(basename "$file" .md)
       echo "  • Task #$task_num in $epic_name"
     done
@@ -64,7 +69,13 @@ if [ -d ".claude/epics" ]; then
 fi
 
 # Summary
-total=$(find .claude -name "*.md" -exec grep -l -i "$query" {} \; 2>/dev/null | wc -l)
+total=$(
+  {
+    ccpm_list_prd_files
+    ccpm_list_epic_dirs | while IFS= read -r dir; do printf '%s\n' "$dir/epic.md"; done
+    ccpm_list_task_files
+  } | xargs grep -l -i "$query" 2>/dev/null | wc -l | tr -d '[:space:]'
+)
 echo ""
 echo "📊 Total files with matches: $total"
 

--- a/skill/ccpm/references/scripts/standup.sh
+++ b/skill/ccpm/references/scripts/standup.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 echo "📅 Daily Standup - $(date '+%Y-%m-%d')"
 echo "================================"
@@ -15,7 +20,13 @@ echo "===================="
 echo ""
 
 # Find files modified today
-recent_files=$(find .claude -name "*.md" -mtime -1 2>/dev/null)
+recent_files=$(
+  {
+    ccpm_recent_activity_roots | while IFS= read -r root; do
+      find "$root" -name "*.md" -mtime -1 2>/dev/null
+    done
+  } | sort -u
+)
 
 if [ -n "$recent_files" ]; then
   # Count by type
@@ -36,24 +47,26 @@ fi
 echo ""
 echo "🔄 Currently In Progress:"
 # Show active work items
-for updates_dir in .claude/epics/*/updates/*/; do
-  [ -d "$updates_dir" ] || continue
-  if [ -f "$updates_dir/progress.md" ]; then
-    issue_num=$(basename "$updates_dir")
-    epic_name=$(basename $(dirname $(dirname "$updates_dir")))
-    completion=$(grep "^completion:" "$updates_dir/progress.md" | head -1 | sed 's/^completion: *//')
-    echo "  • Issue #$issue_num ($epic_name) - ${completion:-0%} complete"
-  fi
-done
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
+  while IFS= read -r updates_dir; do
+    [ -d "$updates_dir" ] || continue
+    if [ -f "$updates_dir/progress.md" ]; then
+      issue_num=$(basename "$updates_dir")
+      epic_name=$(basename "$epic_dir")
+      completion=$(grep "^completion:" "$updates_dir/progress.md" | head -1 | sed 's/^completion: *//')
+      echo "  • Issue #$issue_num ($epic_name) - ${completion:-0%} complete"
+    fi
+  done < <(find "$epic_dir/updates" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+done < <(ccpm_list_epic_dirs)
 
 echo ""
 echo "⏭️ Next Available Tasks:"
 # Show top 3 available tasks
 count=0
-for epic_dir in .claude/epics/*/; do
-  [ -d "$epic_dir" ] || continue
-  for task_file in "$epic_dir"/[0-9]*.md; do
-    [ -f "$task_file" ] || continue
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
+  while IFS= read -r task_file; do
     status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
     if [ "$status" != "open" ] && [ -n "$status" ]; then
       continue
@@ -66,21 +79,36 @@ for epic_dir in .claude/epics/*/; do
     else
       deps=""
     fi
-    if [ -z "$deps" ] || [ "$deps" = "depends_on:" ]; then
+    ready=true
+    if [ -n "$deps" ] && [ "$deps" != "depends_on:" ]; then
+      for dep in $(echo "$deps" | sed 's/,/ /g'); do
+        dep_file="$(ccpm_task_file_for_epic_issue "$epic_dir" "$dep" 2>/dev/null || true)"
+        if [ ! -f "$dep_file" ]; then
+          ready=false
+          break
+        fi
+        dep_status=$(grep "^status:" "$dep_file" | head -1 | sed 's/^status: *//')
+        if [ "$dep_status" != "closed" ] && [ "$dep_status" != "completed" ]; then
+          ready=false
+          break
+        fi
+      done
+    fi
+    if $ready; then
       task_name=$(grep "^name:" "$task_file" | head -1 | sed 's/^name: *//')
       task_num=$(basename "$task_file" .md)
       echo "  • #$task_num - $task_name"
       ((count++))
       [ $count -ge 3 ] && break 2
     fi
-  done
-done
+  done < <(ccpm_list_task_files_for_epic "$epic_dir")
+done < <(ccpm_list_epic_dirs)
 
 echo ""
 echo "📊 Quick Stats:"
-total_tasks=$(find .claude/epics -name "[0-9]*.md" 2>/dev/null | wc -l)
-open_tasks=$(find .claude/epics -name "[0-9]*.md" -exec grep -l "^status: *open" {} \; 2>/dev/null | wc -l)
-closed_tasks=$(find .claude/epics -name "[0-9]*.md" -exec grep -l "^status: *closed" {} \; 2>/dev/null | wc -l)
+total_tasks=$(ccpm_list_task_files | wc -l | tr -d '[:space:]')
+open_tasks=$(ccpm_list_task_files | xargs grep -l "^status: *open" 2>/dev/null | wc -l | tr -d '[:space:]')
+closed_tasks=$(ccpm_list_task_files | xargs grep -l "^status: *closed" 2>/dev/null | wc -l | tr -d '[:space:]')
 echo "  Tasks: $open_tasks open, $closed_tasks closed, $total_tasks total"
 
 exit 0

--- a/skill/ccpm/references/scripts/status.sh
+++ b/skill/ccpm/references/scripts/status.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 echo "Getting status..."
 echo ""
@@ -10,8 +15,8 @@ echo "================"
 echo ""
 
 echo "📄 PRDs:"
-if [ -d ".claude/prds" ]; then
-  total=$(ls .claude/prds/*.md 2>/dev/null | wc -l)
+if [ -n "$(ccpm_list_prd_files)" ]; then
+  total=$(ccpm_list_prd_files | wc -l | tr -d '[:space:]')
   echo "  Total: $total"
 else
   echo "  No PRDs found"
@@ -19,8 +24,8 @@ fi
 
 echo ""
 echo "📚 Epics:"
-if [ -d ".claude/epics" ]; then
-  total=$(ls -d .claude/epics/*/ 2>/dev/null | grep -v '/archived/$' | wc -l)
+if [ -n "$(ccpm_list_epic_dirs)" ]; then
+  total=$(ccpm_list_epic_dirs | wc -l | tr -d '[:space:]')
   echo "  Total: $total"
 else
   echo "  No epics found"
@@ -28,10 +33,10 @@ fi
 
 echo ""
 echo "📝 Tasks:"
-if [ -d ".claude/epics" ]; then
-  total=$(find .claude/epics -path "*/archived/*" -prune -o -name "[0-9]*.md" -print 2>/dev/null | wc -l)
-  open=$(find .claude/epics -path "*/archived/*" -prune -o -name "[0-9]*.md" -print 2>/dev/null | xargs grep -l "^status: *open" 2>/dev/null | wc -l)
-  closed=$(find .claude/epics -path "*/archived/*" -prune -o -name "[0-9]*.md" -print 2>/dev/null | xargs grep -l "^status: *closed" 2>/dev/null | wc -l)
+if [ -n "$(ccpm_list_task_files)" ]; then
+  total=$(ccpm_list_task_files | wc -l | tr -d '[:space:]')
+  open=$(ccpm_list_task_files | xargs grep -l "^status: *open" 2>/dev/null | wc -l | tr -d '[:space:]')
+  closed=$(ccpm_list_task_files | xargs grep -l "^status: *closed" 2>/dev/null | wc -l | tr -d '[:space:]')
   echo "  Open: $open"
   echo "  Closed: $closed"
   echo "  Total: $total"

--- a/skill/ccpm/references/scripts/validate.sh
+++ b/skill/ccpm/references/scripts/validate.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/layout-common.sh"
 
 echo "Validating PM System..."
 echo ""
@@ -14,33 +19,52 @@ warnings=0
 # Check directory structure
 echo "📁 Directory Structure:"
 [ -d ".claude" ] && echo "  ✅ .claude directory exists" || { echo "  ❌ .claude directory missing"; ((errors++)); }
-[ -d ".claude/prds" ] && echo "  ✅ PRDs directory exists" || echo "  ⚠️ PRDs directory missing"
-[ -d ".claude/epics" ] && echo "  ✅ Epics directory exists" || echo "  ⚠️ Epics directory missing"
-[ -d ".claude/rules" ] && echo "  ✅ Rules directory exists" || echo "  ⚠️ Rules directory missing"
+PRD_DIR="$(ccpm_resolve_prd_dir --allow-missing 2>/dev/null || true)"
+[ -n "$PRD_DIR" ] && [ -d "$PRD_DIR" ] && echo "  ✅ PRD directory exists: $PRD_DIR" || echo "  ⚠️ PRD directory missing"
+[ -n "$(ccpm_list_epic_dirs)" ] && echo "  ✅ Epic directories found" || echo "  ⚠️ No epics found"
+if [ -d ".claude/rules" ] || [ -d ".cursor/ccpm/rules" ]; then
+  echo "  ✅ Rules directory exists"
+else
+  echo "  ⚠️ Rules directory missing"
+fi
 echo ""
 
 # Check for orphaned files
 echo "🗂️ Data Integrity:"
 
 # Check epics have epic.md files
-for epic_dir in .claude/epics/*/; do
-  [ -d "$epic_dir" ] || continue
+while IFS= read -r epic_dir; do
+  [ -n "$epic_dir" ] || continue
   if [ ! -f "$epic_dir/epic.md" ]; then
     echo "  ⚠️ Missing epic.md in $(basename "$epic_dir")"
     ((warnings++))
   fi
-done
+done < <(ccpm_list_epic_dirs)
+
+duplicate_epics="$(ccpm_list_epic_dirs | while IFS= read -r epic_dir; do basename "$epic_dir"; done | sort | uniq -d)"
+if [ -n "$duplicate_epics" ]; then
+  while IFS= read -r epic_name; do
+    [ -n "$epic_name" ] || continue
+    echo "  ❌ Duplicate epic name: $epic_name"
+    ((errors++))
+  done <<< "$duplicate_epics"
+fi
 
 # Check for tasks without epics
-orphaned=$(find .claude -name "[0-9]*.md" -not -path ".claude/epics/*/*" 2>/dev/null | wc -l)
+orphaned=$(
+  ccpm_list_task_files | while IFS= read -r task_file; do
+    epic_dir="$(ccpm_epic_dir_from_task_file "$task_file")"
+    [ -f "$epic_dir/epic.md" ] || printf '%s\n' "$task_file"
+  done | wc -l | tr -d '[:space:]'
+)
 [ $orphaned -gt 0 ] && echo "  ⚠️ Found $orphaned orphaned task files" && ((warnings++))
 
 # Check for broken references
 echo ""
 echo "🔗 Reference Check:"
 
-for task_file in .claude/epics/*/[0-9]*.md; do
-  [ -f "$task_file" ] || continue
+while IFS= read -r task_file; do
+  [ -n "$task_file" ] || continue
 
   deps_line=$(grep "^depends_on:" "$task_file" | head -1)
   if [ -n "$deps_line" ]; then
@@ -50,15 +74,15 @@ for task_file in .claude/epics/*/[0-9]*.md; do
     deps=""
   fi
   if [ -n "$deps" ] && [ "$deps" != "depends_on:" ]; then
-    epic_dir=$(dirname "$task_file")
+    epic_dir="$(ccpm_epic_dir_from_task_file "$task_file")"
     for dep in $deps; do
-      if [ ! -f "$epic_dir/$dep.md" ]; then
+      if ! ccpm_task_file_for_epic_issue "$epic_dir" "$dep" >/dev/null 2>&1; then
         echo "  ⚠️ Task $(basename "$task_file" .md) references missing task: $dep"
         ((warnings++))
       fi
     done
   fi
-done
+done < <(ccpm_list_task_files)
 
 if [ $warnings -eq 0 ] && [ $errors -eq 0 ]; then
   echo "  ✅ All references valid"
@@ -69,7 +93,7 @@ echo ""
 echo "📝 Frontmatter Validation:"
 invalid=0
 
-for file in $(find .claude -name "*.md" -path "*/epics/*" -o -path "*/prds/*" 2>/dev/null); do
+for file in $( { ccpm_list_prd_files; ccpm_list_epic_dirs | while IFS= read -r dir; do printf '%s\n' "$dir/epic.md"; done; ccpm_list_task_files; } ); do
   if ! grep -q "^---" "$file"; then
     echo "  ⚠️ Missing frontmatter: $(basename "$file")"
     ((invalid++))

--- a/skill/ccpm/references/structure.md
+++ b/skill/ccpm/references/structure.md
@@ -9,41 +9,21 @@ This phase converts a technical epic into concrete, numbered task files with dep
 **Trigger**: User wants to break an epic into actionable tasks.
 
 ### Preflight
-- Verify `.claude/epics/<name>/epic.md` exists with valid frontmatter.
-- If numbered task files (001.md, 002.md...) already exist in the epic directory, list them and confirm deletion before recreating.
-- If epic status is "completed", warn the user before proceeding.
+- Resolve the epic with `bash references/scripts/resolve-epic-dir.sh <epic-name>`.
+- Use `<epic-dir>/issues/` as the canonical task directory.
+- If numbered task files already exist in `issues/` or legacy epic root, list them and confirm deletion before recreating.
+- If the epic is completed, warn before proceeding.
 
 ### Process
 
-Read the epic fully. Analyze for parallelism — which pieces of work can happen simultaneously without file conflicts?
+Read the epic fully. Analyze which work can happen simultaneously without file conflicts.
 
-**Task types to consider:**
-- Setup: environment, scaffolding, dependencies
-- Data: models, schemas, migrations
-- API: endpoints, services, integration
-- UI: components, pages, styling
-- Tests: unit, integration, e2e
-- Docs: README, API docs, changelogs
+Create task files as:
+- `<epic-dir>/issues/001.md`
+- `<epic-dir>/issues/002.md`
+- ...
 
-**Parallelization strategy by epic size:**
-- Small (<5 tasks): create sequentially
-- Medium (5–10 tasks): batch into 2–3 groups, spawn parallel Task agents
-- Large (>10 tasks): analyze dependencies first, launch parallel agents (max 5 concurrent), create dependent tasks after prerequisites
-
-For parallel creation, use the Task tool:
-```yaml
-Task:
-  description: "Create task files batch N"
-  subagent_type: "general-purpose"
-  prompt: |
-    Create task files for epic: <name>
-    Tasks to create: [list 3-4 tasks]
-    Save to: .claude/epics/<name>/001.md, 002.md, etc.
-    Follow the task file format exactly.
-    Return: list of files created.
-```
-
-### Task File Format
+Task file format:
 
 ```markdown
 ---
@@ -78,11 +58,15 @@ conflicts_with: []
 - [ ] Code reviewed
 ```
 
-**Numbering**: sequential 001.md, 002.md, etc. Tasks are renamed to GitHub issue numbers after sync — do not hard-code dependencies by filename, use the `depends_on` array.
+### Parallelization Strategy
+
+- Small epic: create sequentially
+- Medium epic: batch into 2–3 groups
+- Large epic: analyze dependencies first, then parallelize
 
 ### After Creating All Tasks
 
-Append a summary to the epic file:
+Append a summary to `<epic-dir>/epic.md`:
 
 ```markdown
 ## Tasks Created
@@ -95,12 +79,4 @@ Sequential tasks: N
 Estimated total effort: N hours
 ```
 
-**After completion**: Confirm "✅ Created N tasks for epic: <name>" and suggest: "Ready to push to GitHub? Say: sync the <name> epic"
-
----
-
-## Dependency Rules
-- `depends_on` lists task numbers that must complete before this task can start.
-- `parallel: true` means the task can run concurrently with others it doesn't conflict with.
-- `conflicts_with` lists tasks that touch the same files — these cannot run in parallel.
-- Circular dependencies are an error — check before finalizing.
+**After completion**: Confirm the resolved `issues/` path and suggest syncing the epic to GitHub.

--- a/skill/ccpm/references/sync.md
+++ b/skill/ccpm/references/sync.md
@@ -6,7 +6,7 @@ This phase covers pushing local epics/tasks to GitHub as issues, syncing progres
 
 ## Repository Safety Check
 
-**Always run this before any GitHub write operation:**
+Always run this before any GitHub write operation:
 
 ```bash
 remote_url=$(git remote get-url origin 2>/dev/null || echo "")
@@ -25,92 +25,19 @@ REPO=$(echo "$remote_url" | sed 's|.*github.com[:/]||' | sed 's|\.git$||')
 **Trigger**: User wants to push a local epic and its tasks to GitHub as issues.
 
 ### Preflight
-- Verify `.claude/epics/<name>/epic.md` exists.
-- Verify numbered task files exist — if none: "❌ No tasks to sync. Decompose the epic first."
+- Resolve `EPIC_DIR` with `bash references/scripts/resolve-epic-dir.sh <epic-name>`.
+- Verify `EPIC_DIR/epic.md` exists.
+- Use `EPIC_DIR/issues/*.md` as the canonical task set; fall back to legacy task files only if `issues/` does not exist.
 
 ### Process
 
-**Step 1 — Create epic issue:**
-
-Strip frontmatter from epic.md, then:
-```bash
-sed '1,/^---$/d; 1,/^---$/d' .claude/epics/<name>/epic.md > /tmp/epic-body.md
-epic_number=$(gh issue create \
-  --repo "$REPO" \
-  --title "Epic: <name>" \
-  --body-file /tmp/epic-body.md \
-  --label "epic,epic:<name>,feature" \
-  --json number -q .number)
-```
-
-**Step 2 — Create task sub-issues:**
-
-Check if `gh-sub-issue` extension is available:
-```bash
-if gh extension list | grep -q "yahsan2/gh-sub-issue"; then
-  use_subissues=true
-fi
-```
-
-For <5 tasks: create sequentially.
-For ≥5 tasks: use parallel Task agents (3-4 tasks per batch).
-
-Per task:
-```bash
-sed '1,/^---$/d; 1,/^---$/d' <task_file> > /tmp/task-body.md
-task_number=$(gh issue create \
-  --repo "$REPO" \
-  --title "<task_name>" \
-  --body-file /tmp/task-body.md \
-  --label "task,epic:<name>" \
-  --json number -q .number)
-# or with sub-issues:
-# gh sub-issue create --parent $epic_number ...
-```
-
-**Step 3 — Rename task files and update references:**
-
-After all issues are created, rename `001.md` → `<issue_number>.md` and update all `depends_on`/`conflicts_with` arrays to use real issue numbers (not sequential numbers).
-
-```bash
-# Build old→new mapping, then for each task file:
-sed -i.bak "s/\b001\b/<new_num_1>/g" <file>  # repeat for each mapping
-mv 001.md <new_num>.md
-```
-
-**Step 4 — Update frontmatter:**
-```bash
-current_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-# Update github: and updated: fields in epic.md and each task file
-github_url="https://github.com/$REPO/issues/<number>"
-sed -i.bak "/^github:/c\\github: $github_url" <file>
-sed -i.bak "/^updated:/c\\updated: $current_date" <file>
-rm <file>.bak
-```
-
-**Step 5 — Create worktree for the epic:**
-```bash
-git checkout main && git pull origin main
-git worktree add ../epic-<name> -b epic/<name>
-```
-
-**Step 6 — Create github-mapping.md:**
-```markdown
-# GitHub Issue Mapping
-Epic: #<N> - https://github.com/<repo>/issues/<N>
-Tasks:
-- #<N>: <title> - https://github.com/<repo>/issues/<N>
-Synced: <datetime>
-```
-
-**Output:**
-```
-✅ Synced epic <name> to GitHub
-  Epic: #<N>
-  Tasks: N sub-issues
-  Worktree: ../epic-<name>
-  Next: "start working on issue <N>" or "start the <name> epic"
-```
+1. Create the epic issue from `EPIC_DIR/epic.md`.
+2. Create task issues from `EPIC_DIR/issues/*.md`.
+3. Rename task files from `001.md` to `<issue-number>.md` within `EPIC_DIR/issues/`.
+4. Update `depends_on` / `conflicts_with` references to real GitHub issue numbers.
+5. Update frontmatter `github:` and `updated:` fields.
+6. Create `EPIC_DIR/github-mapping.md`.
+7. Create the worktree for the epic branch.
 
 ---
 
@@ -119,40 +46,15 @@ Synced: <datetime>
 **Trigger**: User wants to sync local development progress to a GitHub issue as a comment.
 
 ### Preflight
-- Verify issue exists: `gh issue view <N> --json state`
-- Check `.claude/epics/*/updates/<N>/` exists with a `progress.md` file.
-- Check `last_sync` in progress.md — if synced <5 minutes ago, confirm before proceeding.
+- Verify the issue exists.
+- Resolve the task file with `resolve-issue-file.sh`.
+- Use `<epic-dir>/updates/<N>/progress.md` as the progress source.
 
 ### Process
 
-Gather updates from `.claude/epics/<epic>/updates/<N>/` (progress.md, notes.md, commits.md).
-
-Format and post a comment:
-```bash
-gh issue comment <N> --body-file /tmp/update-comment.md
-```
-
-Comment format:
-```markdown
-## 🔄 Progress Update - <date>
-
-### ✅ Completed Work
-### 🔄 In Progress
-### 📝 Technical Notes
-### 📊 Acceptance Criteria Status
-### 🚀 Next Steps
-### ⚠️ Blockers
-
----
-*Progress: N% | Synced at <timestamp>*
-```
-
-After posting: update `last_sync` in progress.md frontmatter, update `updated` in the task file.
-
-Add sync marker to local files to prevent duplicate comments:
-```markdown
-<!-- SYNCED: <datetime> -->
-```
+Gather updates from `<epic-dir>/updates/<N>/` and post a progress comment to GitHub. After posting:
+- update `last_sync` in `progress.md`
+- update `updated:` in the resolved task file
 
 ---
 
@@ -162,20 +64,11 @@ Add sync marker to local files to prevent duplicate comments:
 
 ### Process
 
-1. Find the local task file (`.claude/epics/*/<N>.md`).
-2. Update frontmatter: `status: closed`, `updated: <now>`.
-3. Post completion comment:
-```bash
-echo "✅ Task completed — all acceptance criteria met." | gh issue comment <N> --body-file -
-gh issue close <N>
-```
-4. Check off the task in the epic issue body:
-```bash
-gh issue view <epic_N> --json body -q .body > /tmp/epic-body.md
-sed -i "s/- \[ \] #<N>/- [x] #<N>/" /tmp/epic-body.md
-gh issue edit <epic_N> --body-file /tmp/epic-body.md
-```
-5. Recalculate and update epic progress: `progress = closed_tasks / total_tasks * 100`
+1. Resolve the local task file with `resolve-issue-file.sh`.
+2. Update `status: closed` and `updated:`.
+3. Post a completion comment and close the GitHub issue.
+4. Update the parent epic issue body.
+5. Recalculate epic progress based on `EPIC_DIR/issues/*.md`.
 
 ---
 
@@ -183,114 +76,25 @@ gh issue edit <epic_N> --body-file /tmp/epic-body.md
 
 **Trigger**: User wants to merge a completed epic back to main.
 
-### Preflight
-- Verify worktree `../epic-<name>` exists.
-- Check for uncommitted changes in the worktree — block if dirty.
-- Warn if any task issues are still open.
-
 ### Process
 
-```bash
-# From worktree: run project tests if detectable
-cd ../epic-<name>
-# detect and run: npm test / pytest / cargo test / go test / etc.
-
-# From main repo:
-git checkout main && git pull origin main
-git merge epic/<name> --no-ff -m "Merge epic: <name>"
-git push origin main
-
-# Cleanup
-git worktree remove ../epic-<name>
-git branch -d epic/<name>
-git push origin --delete epic/<name>
-
-# Archive
-mkdir -p .claude/epics/archived/
-mv .claude/epics/<name> .claude/epics/archived/
-
-# Close GitHub issues
-epic_issue=$(grep 'github:' .claude/epics/archived/<name>/epic.md | grep -oE '[0-9]+$')
-gh issue close $epic_issue -c "Epic completed and merged to main"
-```
-
-Update epic.md frontmatter: `status: completed`.
+- run tests from the epic worktree
+- merge `epic/<name>` into `main`
+- remove the worktree
+- archive the epic to `<prd-dir>/epics/.archived/<name>/`
+- close the GitHub epic issue
 
 ---
 
 ## Reporting a Bug Against a Completed Issue
 
-**Trigger**: User finds a bug while testing a completed or in-progress issue — e.g. "found a bug in issue 42", "email validation is broken, came up while testing issue 42".
-
-The workflow should stay automated: create a linked bug task without losing context from the original issue.
+**Trigger**: User finds a bug while testing a completed or in-progress issue.
 
 ### Process
 
-**Step 1 — Read the original issue for context:**
-```bash
-gh issue view <original_N> --json title,body,labels
-```
-Also read the local task file if it exists: `.claude/epics/*/<original_N>.md`
-
-**Step 2 — Create a local bug task file:**
-
-```markdown
----
-name: Bug: <short description>
-status: open
-created: <run: date -u +"%Y-%m-%dT%H:%M:%SZ">
-updated: <same>
-github: (will be set on sync)
-depends_on: []
-parallel: false
-conflicts_with: []
-bug_for: <original_N>
----
-
-# Bug: <short description>
-
-## Context
-Found while working on / testing issue #<original_N>: <original title>
-
-## Description
-<what's broken>
-
-## Steps to Reproduce
-<steps>
-
-## Expected vs Actual
-- Expected: 
-- Actual: 
-
-## Acceptance Criteria
-- [ ] Bug is fixed
-- [ ] Original issue #<original_N> behaviour is unaffected
-
-## Effort Estimate
-- Size: XS/S
-```
-
-Save to `.claude/epics/<same_epic_as_original>/bug-<original_N>-<slug>.md`
-
-**Step 3 — Create a linked GitHub issue:**
-```bash
-gh issue create \
-  --repo "$REPO" \
-  --title "Bug: <short description>" \
-  --body "$(cat /tmp/bug-body.md)" \
-  --label "bug,epic:<epic_name>" \
-  --json number -q .number
-```
-
-The issue body should open with `Fixes / follow-up to #<original_N>` so GitHub auto-links them.
-
-**Step 4 — Update the local file** with the GitHub issue number and rename to `<new_N>.md`.
-
-**Output:**
-```
-✅ Bug issue created: #<new_N> — "Bug: <short description>"
-  Linked to: #<original_N>
-  Epic: <epic_name>
-
-Start fixing it: "start working on issue <new_N>"
-```
+1. Read the original GitHub issue and resolved local task file.
+2. Create a local bug task in the same epic:
+   - canonical: `<epic-dir>/issues/bug-<original_N>-<slug>.md`
+   - after sync: rename to `<new_N>.md`
+3. Create the linked GitHub issue.
+4. Update the local bug file with the GitHub issue number.

--- a/skill/ccpm/references/track.md
+++ b/skill/ccpm/references/track.md
@@ -1,6 +1,6 @@
 # Track — Know Where Things Stand
 
-Tracking operations use bash scripts directly for speed and consistency. The LLM is not needed for these — just run the script and present the output.
+Tracking operations use bash scripts directly for speed and consistency.
 
 ---
 
@@ -8,156 +8,38 @@ Tracking operations use bash scripts directly for speed and consistency. The LLM
 
 All tracking operations have a corresponding bash script. Run the script; do not reconstruct the output manually.
 
-Scripts live in `references/scripts/` relative to this skill, but need to run from the **project root** (where `.claude/` lives). Run them as:
+Scripts live in `references/scripts/` relative to this skill and operate from the project root. They resolve planning paths through:
+- `resolve-prd-dir.sh`
+- `resolve-prd-path.sh`
+- `resolve-epic-dir.sh`
+- `resolve-issue-file.sh`
 
-```bash
-bash <installed_skill_dir>/references/scripts/<script>.sh [args]
-```
-
-Common install locations:
-- `.claude/skills/ccpm`
-- `.cursor/skills/ccpm`
-- `skills/ccpm`
-
----
-
-## Project Status
-
-**Trigger**: "what's our status", "project status", "overview"
-
-```bash
-bash references/scripts/status.sh
-```
-
-Shows: active epics, open issues count, recent activity.
+That means they work against both:
+- canonical nested storage under `docs/prds/...`
+- legacy `.claude/prds` and `.claude/epics` data until migration is complete
 
 ---
 
-## Standup Report
+## Available Reports
 
-**Trigger**: "standup", "daily standup", "what did we do", "morning update"
-
-```bash
-bash references/scripts/standup.sh
-```
-
-Shows: what was completed yesterday, what's in progress today, any blockers.
-
----
-
-## List Epics
-
-**Trigger**: "list epics", "show epics", "what epics do we have"
-
-```bash
-bash references/scripts/epic-list.sh
-```
-
----
-
-## Show Epic Details
-
-**Trigger**: "show the <name> epic", "epic details for <name>"
-
-```bash
-bash references/scripts/epic-show.sh <name>
-```
-
----
-
-## Epic Status
-
-**Trigger**: "status of the <name> epic", "how far along is <name>"
-
-```bash
-bash references/scripts/epic-status.sh <name>
-```
-
-Shows: task completion breakdown, active agents, blocking issues.
-
----
-
-## List PRDs
-
-**Trigger**: "list PRDs", "what PRDs do we have", "show backlog"
-
-```bash
-bash references/scripts/prd-list.sh
-```
-
----
-
-## PRD Status
-
-**Trigger**: "PRD status", "which PRDs are parsed", "what's in backlog"
-
-```bash
-bash references/scripts/prd-status.sh
-```
-
----
-
-## Search
-
-**Trigger**: "search for <query>", "find issues about <topic>", "look for <term>"
-
-```bash
-bash references/scripts/search.sh "<query>"
-```
-
-Searches local task files, PRDs, and epics for the query term.
-
----
-
-## What's In Progress
-
-**Trigger**: "what's in progress", "what are we working on", "active work"
-
-```bash
-bash references/scripts/in-progress.sh
-```
-
----
-
-## What's Next
-
-**Trigger**: "what should I work on next", "what's next", "next priority"
-
-```bash
-bash references/scripts/next.sh
-```
-
-Shows highest-priority open tasks with no blocking dependencies.
-
----
-
-## What's Blocked
-
-**Trigger**: "what's blocked", "any blockers", "what can't we move on"
-
-```bash
-bash references/scripts/blocked.sh
-```
-
----
-
-## Validate Project State
-
-**Trigger**: "validate", "check project state", "is everything consistent"
-
-```bash
-bash references/scripts/validate.sh
-```
-
-Checks: frontmatter consistency, orphaned files, missing GitHub links, dependency integrity.
+- Project status: `bash references/scripts/status.sh`
+- Standup report: `bash references/scripts/standup.sh`
+- List epics: `bash references/scripts/epic-list.sh`
+- Show epic: `bash references/scripts/epic-show.sh <name>`
+- Epic status: `bash references/scripts/epic-status.sh <name>`
+- List PRDs: `bash references/scripts/prd-list.sh`
+- PRD status: `bash references/scripts/prd-status.sh`
+- Search: `bash references/scripts/search.sh "<query>"`
+- In progress: `bash references/scripts/in-progress.sh`
+- What's next: `bash references/scripts/next.sh`
+- What's blocked: `bash references/scripts/blocked.sh`
+- Validate project state: `bash references/scripts/validate.sh`
+- Migrate legacy planning layout: `bash references/scripts/migrate-layout.sh [--apply]`
 
 ---
 
 ## When Scripts Fail
 
-If a script fails or the output needs interpretation (e.g., an error in the output, or the user asks "what does this mean"), then step in to explain. But always run the script first — don't guess at what status/standup output would look like.
+If a script fails or the user asks for interpretation, explain the output after running the script.
 
-If `.claude/` directory doesn't exist at all, the project hasn't been initialized. Direct the user to run:
-```bash
-bash <installed_skill_dir>/references/scripts/init.sh
-```
+If the repo has no planning root yet, initialize CCPM first so `docs/prds/` and `.claude/.ccpmrc` are created.


### PR DESCRIPTION
## Summary
- moves planning artifacts to `docs/prds/...` by default for the skill-based CCPM line
- keeps `.claude/.ccpmrc`, context, and testing state under `.claude`
- preserves backward compatibility for legacy hidden roots and mixed-layout repos

## Compatibility and Migration
- legacy hidden roots still read correctly
- migration is idempotent and conflict-safe
- duplicate epic names remain globally forbidden
- same-target conflicts quarantine instead of partially merging
- fresh-target ancestor path conflicts are preflighted before any epic move

## Validation
- targeted migration checks were run for fresh-target ancestor conflicts, safe same-target merges, unsupported hidden leftovers, and structural `updates/...` conflicts
- final focused agent re-review found no material issues in scope